### PR TITLE
separate commands in codeblocks

### DIFF
--- a/src/config/media/alsa.md
+++ b/src/config/media/alsa.md
@@ -5,6 +5,8 @@ Install the `alsa-utils` package make sure your user is part of the
 
 ```
 # xbps-install -S alsa-utils
+```
+```
 # usermod -a -G audio <username>
 ```
 

--- a/src/config/media/pulseaudio.md
+++ b/src/config/media/pulseaudio.md
@@ -4,6 +4,8 @@ PulseAudio depends on a `dbus` system daemon, make sure its enabled.
 
 ```
 # xbps-install -S alsa-utils pulseaudio
+```
+```
 # ln -s /etc/sv/dbus /var/service/
 ```
 

--- a/src/config/network/dhcpcd.md
+++ b/src/config/network/dhcpcd.md
@@ -17,8 +17,14 @@ $ ip link show
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: enp3s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
         link/ether ff:ff:ff:ff:ff:ff brd ff:ff:ff:f
+```
+```
 # cp -R /etc/sv/dhcpcd-eth0 /etc/sv/dhcpcd-enp3s0
+```
+```
 # sed -i 's/eth0/enp3s0/' /etc/sv/dhcpcd-enp3s0/run
+```
+```
 # ln -s /etc/sv/dhcpcd-enp3s0 /var/service
 ```
 

--- a/src/config/services/index.md
+++ b/src/config/services/index.md
@@ -36,6 +36,8 @@ retrieve the status for all activated services.
 ```
 # sv status dhcpcd
 run: /var/service/dhcpcd: (pid 659) 561392s
+```
+```
 # sv status /var/service/*
 run: /var/service/agetty-tty1: (pid 658) 561392s
 run: /var/service/agetty-tty2: (pid 639) 561392s
@@ -60,6 +62,8 @@ $ cat /etc/sv/sshd/run
 ssh-keygen -A >/dev/null 2>&1 # Will generate host keys if they don't already exist
 [ -r conf ] && . ./conf
 exec /usr/bin/sshd -D $OPTS
+```
+```
 # echo 'OPTS="-p 2222"' >>/etc/sv/sshd/conf
 ```
 
@@ -72,5 +76,7 @@ available variables.
 [ -r ./conf ] && . ./conf
 exec 2>&1
 exec wpa_supplicant -c ${CONF_FILE:=/etc/wpa_supplicant/wpa_supplicant.conf} -i ${WPA_INTERFACE:=wlan0} ${OPTS:=-s}
+```
+```
 # echo WPA_INTERFACE=wlp3s0 >>/etc/sv/wpa_supplicant/conf
 ```

--- a/src/config/services/logging.md
+++ b/src/config/services/logging.md
@@ -10,9 +10,18 @@ different implementations available.
 provides a package with some basic configuration for it, this makes it
 a good choice if you don't know which one to choose.
 
-``` # xbps-install -S socklog-void # usermod -aG socklog <your
-username> # ln -s /etc/sv/socklog-unix /var/service/ # ln -s
-/etc/sv/nanoklogd /var/service/ ```
+```
+# xbps-install -S socklog-void
+```
+```
+# usermod -aG socklog <username>
+```
+```
+# ln -s /etc/sv/socklog-unix /var/service/
+```
+```
+# ln -s /etc/sv/nanoklogd /var/service/
+```
 
 Other syslog implementations like `rsyslog` and `metalog` are
 available in the package repository too.

--- a/src/config/shell.md
+++ b/src/config/shell.md
@@ -6,7 +6,7 @@ The default shell for users can be changed with the
 [chsh(1)](https://man.voidlinux.org/chsh.1) tool.
 
 ```
-$ chsh -s /bin/bash <user name>
+$ chsh -s /bin/bash <username>
 ```
 
 Make sure to use the same path to the shell as its in `/etc/shells` or

--- a/src/config/xorg/index.md
+++ b/src/config/xorg/index.md
@@ -19,8 +19,14 @@ and the cgmanager services are activated too.
 
 ```
 # xbps-install -S ConsoleKit2
+```
+```
 # ln -s /etc/sv/dbus /var/service/
+```
+```
 # ln -s /etc/sv/cgmanager /var/service/
+```
+```
 # ln -s /etc/sv/consolekit /var/service/
 ```
 

--- a/src/maintenance/man.md
+++ b/src/maintenance/man.md
@@ -18,6 +18,8 @@ database that can be updated and generated with the
 
 ```
 # makewhatis -a
+```
+```
 $ apropos chroot
 chroot(1) - run command or interactive shell with special root directory
 xbps-uchroot(1) - XBPS utility to chroot and bind mount with Linux namespaces
@@ -35,5 +37,7 @@ $ xbps-query -Rs man-pages
 [*] man-pages-4.11_1        Linux Documentation Project (LDP) manual pages
 [-] man-pages-devel-4.11_1  Linux Documentation Project (LDP) manual pages - development pages
 [-] man-pages-posix-2013a_3 Manual pages about POSIX systems
+```
+```
 # xbps-install -S man-pages-devel man-pages-posix
 ```

--- a/src/maintenance/packages/debugging.md
+++ b/src/maintenance/packages/debugging.md
@@ -8,6 +8,8 @@ with the `-dbg` suffix.
 
 ```
 $ xbps-install -S void-repo-debug
+```
+```
 $ xbps-install -S <package name>-dbg
 ```
 
@@ -18,5 +20,7 @@ debug packages including dependencies for a package.
 $ xdbg bash
 bash-dbg
 glibc-dbg
+```
+```
 # xbps-install -S $(xdbg bash)
 ```

--- a/src/maintenance/packages/files.md
+++ b/src/maintenance/packages/files.md
@@ -19,6 +19,8 @@ the void package repository.
 
 ```
 # xbps-install -Su xtools
+```
+```
 $ xlocate -S
 From https://repo.voidlinux.org/xlocate/xlocate
  + 16d97bfe86...2ad1a4a8d1 master -> master (forced update) $ xlocate
@@ -27,4 +29,5 @@ fizz nim-0.17.0_1 /usr/lib/nim/examples/fizzbuzz.nim ponysay-3.0.2_1
 /usr/share/ponysay/ponies/cherrycola.pony ponysay-3.0.2_1
 /usr/share/ponysay/ttyponies/cherryfizzy.pony ->
 /usr/share/ponysay/ttyponies/cherrycola.pony supertux2-data-0.5.1_1
-/usr/share/supertux2/sounds/fizz.wav ```
+/usr/share/supertux2/sounds/fizz.wav
+```

--- a/src/maintenance/packages/mirrors.md
+++ b/src/maintenance/packages/mirrors.md
@@ -32,7 +32,11 @@ Copy all repository configuration files from `/usr/share/xbps.d` to
 
 ```
 # mkdir -p /etc/xbps.d
+```
+```
 # cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
+```
+```
 # sed -i 's|https://repo.voidlinux.org/current|<repository>|g' /etc/xbps.d/*-repository-*.conf
 ```
 
@@ -47,4 +51,3 @@ $ xbps-query -L
    47 https://alpha.de.repo.voidlinux.org/current/nonfree (RSA signed)
  5368 https://alpha.de.repo.voidlinux.org/current/debug (RSA signed)
 ```
-


### PR DESCRIPTION
I've split all separate commands in codeblocks so that they are in their own codeblocks, for the sake of clarity.

For example:
```
$ cat /etc/sv/sshd/run
#!/bin/sh
ssh-keygen -A >/dev/null 2>&1 # Will generate host keys if they don't already exist
[ -r conf ] && . ./conf
exec /usr/bin/sshd -D $OPTS
# echo 'OPTS="-p 2222"' >>/etc/sv/sshd/conf
```
should be
```
$ cat /etc/sv/sshd/run
#!/bin/sh
ssh-keygen -A >/dev/null 2>&1 # Will generate host keys if they don't already exist
[ -r conf ] && . ./conf
exec /usr/bin/sshd -D $OPTS
```
```
# echo 'OPTS="-p 2222"' >>/etc/sv/sshd/conf
```