### PR TITLE
mirrors: squish links

### DIFF
--- a/src/installation/liveimages/downloading.md
+++ b/src/installation/liveimages/downloading.md
@@ -1,7 +1,7 @@
 # Downloading Images
 
 Live images can be downloaded from
-[https://alpha.de.repo.voidlinux.org/live/current/](https://alpha.de.repo.voidlinux.org/live/current/).
+<https://alpha.de.repo.voidlinux.org/live/current/>
 
 ### Verifying integrity
 
@@ -34,7 +34,7 @@ The file is signed with the Void Images key:
 
 You can use [gpg(1)](https://man.voidlinux.org/gpg.1) to receive the
 key from a keyserver using the following command or download it from
-[https://alpha.de.repo.voidlinux.eu/live/current/void_images.asc](https://alpha.de.repo.voidlinux.org/live/current/void_images.asc).
+<https://alpha.de.repo.voidlinux.eu/live/current/void_images.asc>.
 
 ```
 $ gpg --recv-keys B48282A4

--- a/src/maintenance/packages/mirrors.md
+++ b/src/maintenance/packages/mirrors.md
@@ -6,22 +6,22 @@
 
 | Repository | Location |
 |:--------|:-------:|
-| [http://alpha.de.repo.voidlinux.org](http://alpha.de.repo.voidlinux.org) | EU: Germany |
-| [http://beta.de.repo.voidlinux.org](http://beta.de.repo.voidlinux.org) | EU: Germany |
-| [http://alpha.us.repo.voidlinux.org](http://alpha.us.repo.voidlinux.org) | USA: Kansas City |
-| [http://mirror.clarkson.edu/voidlinux/](http://mirror.clarkson.edu/voidlinux/) | USA: New York |
-| [http://mirrors.servercentral.com/voidlinux/](http://mirror.clarkson.edu/voidlinux/) | USA: Chicago |
+| <http://alpha.de.repo.voidlinux.org> | EU: Germany |
+| <http://beta.de.repo.voidlinux.org> | EU: Germany |
+| <http://alpha.us.repo.voidlinux.org> | USA: Kansas City |
+| <http://mirror.clarkson.edu/voidlinux/> | USA: New York |
+| <http://mirrors.servercentral.com/voidlinux/> | USA: Chicago |
 
 ### Tier 2 Mirrors
 
 
 | Repository | Location |
 |:--------|:-------:|
-| [http://mirror.aarnet.edu.au/pub/voidlinux/](http://mirror.aarnet.edu.au/pub/voidlinux/) | AU: Canberra |
-| [http://ftp.swin.edu.au/voidlinux/](http://ftp.swin.edu.au/voidlinux/) | AU: Melbourne |
-| [http://ftp.acc.umu.se/mirror/voidlinux.eu/](http://ftp.acc.umu.se/mirror/voidlinux.eu/) | EU: Sweden |
-| [https://mirrors.dotsrc.org/voidlinux/](https://mirrors.dotsrc.org/voidlinux/) | EU: Denmark |
-| [http://www.gtlib.gatech.edu/pub/VoidLinux/](http://www.gtlib.gatech.edu/pub/VoidLinux/) | USA: Atlanta |
+| <http://mirror.aarnet.edu.au/pub/voidlinux/> | AU: Canberra |
+| <http://ftp.swin.edu.au/voidlinux/> | AU: Melbourne |
+| <http://ftp.acc.umu.se/mirror/voidlinux.eu/> | EU: Sweden |
+| <https://mirrors.dotsrc.org/voidlinux/> | EU: Denmark |
+| <http://www.gtlib.gatech.edu/pub/VoidLinux/> | USA: Atlanta |
 
 
 


### PR DESCRIPTION
Change all links with urls printed as is to be <http://.../> format for maintainability and readability.