### PR TITLE
Try to clean up some of the installation documents

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,11 +2,12 @@
 
 - [About](./about/index.md)
    - [History](./about/history/index.md)
+- [How to Read the Handbook](./howtoread/index.md)
 - [Installation](./installation/index.md)
    - [Base System Requirements](./installation/base-requirements.md)
    - [Live Installers](./installation/live-images/index.md)
       - [Downloading Images](./installation/live-images/downloading.md)
-      - [Preparing Installation Media](./installation/live-images/prep.md)
+      - [Prepare Installation Media](./installation/live-images/prep.md)
       - [Partitioning Notes](./installation/live-images/partitions.md)
       - [Installation Guide](./installation/live-images/guide.md)
    - [Guides](./installation/guides/index.md)
@@ -48,4 +49,3 @@
 - [Contributing](./contributing/index.md)
    - [Void Docs](./contributing/void-docs/index.md)
       - [Style Guide](./contributing/void-docs/styleguide.md)
-

--- a/src/howtoread/index.md
+++ b/src/howtoread/index.md
@@ -1,0 +1,8 @@
+# How to Read the Handbook
+
+## Examples
+
+Examples in this guide may have snippets of commands to be run in your shell.
+When you see these, any line beginning with `$` is run as your normal user. A
+line beginning with `#` are run as either root. After either of these lines,
+there may be example output from the command.

--- a/src/installation/base-requirements.md
+++ b/src/installation/base-requirements.md
@@ -9,12 +9,11 @@ following minimums for most installations:
 | x86_64-musl  | EM64T            | 96MB | 350MB   |
 | i686-glibc   | Pentium 4 (SSE2) | 96MB | 350MB   |
 
-> Note: ''Flavor'' installations do require more resources, depending on which
-> environment you choose.
+> Note: Flavor installations require more resources. How much more depends on
+> the flavor.
 
 Void is not available for i386, i486, or i586 architectures.
 
 It is highly recommended to have a network connection available during install
 to download updates, but this is not required. ISO images contain installation
 data on-disc and can be installed without network connectivity.
-

--- a/src/installation/index.md
+++ b/src/installation/index.md
@@ -1,6 +1,5 @@
 # Installation
 
 This section includes all the information you could ever want to know about the
-process of installing Void in the abstract, for specific guides, see the guides
-subsection.
-
+process of installing Void in the abstract. For specific guides, see the
+[Guides](./guides/index.md) subsection.

--- a/src/installation/live-images/downloading.md
+++ b/src/installation/live-images/downloading.md
@@ -1,40 +1,53 @@
 # Downloading Images
 
-Live images can be downloaded from
-<https://alpha.de.repo.voidlinux.org/live/current/>.
+The most recent live images can be downloaded from
+<https://alpha.de.repo.voidlinux.org/live/current/>. Previous releases can be
+found under <https://alpha.de.repo.voidlinux.org/live/>, organized by date.
 
-### Verifying integrity
+## Verify Images
 
-The image release directories contain a `sha256sums.txt` and a
-`sha256sums.txt.asc` file to verify the integrity of the downloaded images.
+Each image releases's directory contains two files used to verify the image(s)
+you download. First, there is a `sha256sums.txt` file containing image checksums
+to verify the integrity of the downloaded images. Second is the
+`sha256sums.txt.sig` file, used to verify the authenticity of the checksums.
+
+We want to verify both the image's integrity and authenticity, so for this, we
+want to download both files:
 
 ```
 $ wget http://alpha.de.repo.voidlinux.org/live/current/sha256sums.txt{,.sig}
 ```
 
-You can now verify the integrity of downloaded file using
-[sha256sum(1)](https://man.voidlinux.org/sha256sum.1).
+### Verify Image Integrity
+
+You can verify the integrity of a downloaded file using
+[sha256sum(1)](https://man.voidlinux.org/sha256sum.1) with the `sha256sums.txt`
+file we downloaded above. The following sha256sum command will check (`-c`) the
+integrity of only the image(s) you've downloaded:
 
 ```
 $ sha256sum -c --ignore-missing sha256sums.txt
 void-live-x86_64-musl-20170220.iso: OK
 ```
 
-This just makes sure that the file was not corrupted while downloading.
+This verifies that the image is not corrupt.
 
-To verify that the downloaded files are the ones that the Void Linux maintainers
-published and signed you can use pgp.
+### Verify Image Authenticity
+
+To verify that the downloaded `sha256sums.txt` file is the one that the Void
+Linux maintainers published and signed, we use PGP. For this, we need the
+`sha256sums.txt.sig` downloaded above.
 
 The file is signed with the Void Images key:
 
-- Signer: Void Linux Image Signing Key
+- **Signer:** Void Linux Image Signing Key
    <[images@voidlinux.eu](mailto:images@voidlinux.eu)>
-- KeyID: `B48282A4`
-- Fingerprint: `CF24 B9C0 3809 7D8A 4495 8E2C 8DEB DA68 B482 82A4`
+- **KeyID:** `B48282A4`
+- **Fingerprint:** `CF24 B9C0 3809 7D8A 4495 8E2C 8DEB DA68 B482 82A4`
 
 You can use [gpg(1)](https://man.voidlinux.org/gpg.1) to receive the key from a
-keyserver using the following command or download it from
-<https://alpha.de.repo.voidlinux.org/live/current/void_images.asc>.
+keyserver using the command in the following example. You can also download it
+from <https://alpha.de.repo.voidlinux.org/live/current/void_images.asc>.
 
 ```
 $ gpg --recv-keys B48282A4
@@ -43,11 +56,11 @@ gpg: key B48282A4: public key "Void Linux Image Signing Key <images@voidlinux.eu
 gpg: no ultimately trusted keys found
 gpg: Total number processed: 1
 gpg:               imported: 1  (RSA: 1)
-
 ```
 
-You can now verify the signature of the `sha256sums.txt` file with
-[gpg(1)](https://man.voidlinux.org/gpg.1).
+With the key stored locally, you can use
+[gpg(1)](https://man.voidlinux.org/gpg.1) verify the signature of
+`sha256sums.txt` using the `sha256sums.txt.sig` file:
 
 ```
 $ gpg --verify sha256sums.txt.sig 
@@ -59,3 +72,5 @@ gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: CF24 B9C0 3809 7D8A 4495  8E2C 8DEB DA68 B482 82A4
 ```
 
+This verifies that the signature for the checksums is authentic. In turn, we can
+assert that the downloaded images are also authentic if their checksums match.

--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -1,11 +1,11 @@
 # Installation Guide
 
-Once you have [downloaded](./downloading.md) your selected install image and
+Once you have [downloaded](./downloading.md) a Void image to install and
 [prepared](./prep.md) your install media, you are ready to install Void Linux.
 
-> Note: before you begin installation, you should make sure you understand which
-> type of boot process your system will use (BIOS or UEFI) and plan your
-> partitioning appropriately. (See the [partitioning notes](./partitions.md).
+> Note: before you begin installation, you should determine whether your machine
+> boots using BIOS or UEFI. This will affect how you plan partitions. See
+> [Partitioning Notes](./partitions.md) for more detail.
 
 ## Booting
 
@@ -93,7 +93,7 @@ the drive before you exit the partition editor.
 > BIOS users are recommended to choose MBR. Advanced users may use GPT but will
 > need to create a special BIOS partition for `grub` to boot.
 
-See the [partitioning notes](./partitions.md) for more details about
+See the [Partitioning Notes](./partitions.md) for more details about
 partitioning your disk.
 
 ## Filesystems
@@ -126,4 +126,3 @@ successfully, you can reboot into your new Void Linux install!
 
 See the [Post Installation](../../config/postinstall.md) guide for some tips on
 setting up your new system.
-

--- a/src/installation/live-images/index.md
+++ b/src/installation/live-images/index.md
@@ -1,24 +1,28 @@
 # Live Installer Images
 
+Void releases include two types of images: base images and "flavor" images. Both
+types of image, and the different flavor images, are described below.
+
 ## Base Images
 
-Void provides installer images containing a base set of utilities as well as an
-installer program and package files to install a Void base system. Images are
-provided for glibc based systems on both i686 and x86_64 processors, as well as
-musl based systems on x86_64-compatible processors.
+Void provides installer images containing a base set of utilities, an installer
+program, and package files to install a Void base system. Images are provided
+for glibc based systems on both i686 and x86_64 processors, as well as musl
+based systems on x86_64-compatible processors.
 
-## ''Flavor'' Images
+## Flavor Images
 
-In addition to the base image, Void provides additional ''flavors'' which each
+In addition to the base image, Void provides additional "flavors" which each
 include a full desktop environment and web browser, and are pre-configured with
 basic applications for that system. The install process for each of these images
-is the same as the base image. The only difference being which packages are
-included and installed.
+is the same as the base image. The flavor images only differ from the base image
+by which packages are included and installed.
 
-> Note: linux beginners are encouraged to try one of the following ''flavor''
-> images, while more advanced users may prefer installing a minimal base system.
+> Note: we encourage Linux beginners to try one of the flavor images. Users
+> comfortable with a more advanced setup may prefer to install Void from a base
+> image.
 
-## Comparison of ''Flavor'' images
+### Comparison of Flavor Images
 
 Here's a quick overview of the main components and applications included with
 each flavor:
@@ -34,4 +38,3 @@ each flavor:
 | Image viewer      | -                                                     | -               | GPicView                                | LXImage        | Eye of MATE                                                                                                                                                         | Ristretto                                                                                                                           |
 | Archive unpacker  | -                                                     | -               | -                                       | -              | Engrampa                                                                                                                                                            | -                                                                                                                                   |
 | Other             | Mixer, EConnMan (connection manager), Elementary Test | -               | LXTask (task manager), MIME type editor | Screen grabber | Screen grabber, file finder, MATE color picker, MATE font viewer, Disk usage analyzer, Power statistics, System monitor (task manager), Dictionary, Log file viewer | Bulk rename, Orage Globaltime, Orage Calendar, Task Manager, Parole Media Player, Audio Mixer, MIME type editor, Application finder |
-

--- a/src/installation/live-images/prep.md
+++ b/src/installation/live-images/prep.md
@@ -1,46 +1,65 @@
-# Preparing installation media
+# Prepare Installation Media
 
-After [obtaining an image](./downloading.md), it must be written to a storage
-device, such as a USB drive, SD card, or CD/DVD.
+After [downloading a live image](./downloading.md), it must be written to
+bootable media, such as a USB drive, SD card, or CD/DVD.
 
-## Create a bootable USB drive or SD card on Linux
+## Create a Bootable USB Drive or SD Card on Linux
 
-The `dd` command can be used to copy a live image to a storage device.
+### Identify the Device
 
-After connecting the storage device, identify the device path by running:
+Before writing the image, identify the device you'll write it to. You can do
+this using [fdisk(8)](https://man.voidlinux.org/man8/fdisk.8). After connecting
+the storage device, identify the device path by running:
 
 ```
 # fdisk -l
+Disk /dev/sda: 7.5 GiB, 8036286464 bytes, 15695872 sectors
+Disk model: Your USB Device's Model
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
 ```
 
-> Note: on Linux, the path will typically be in the form `/dev/sdX`.
+In the example above, the output shows the USB device as `/dev/sda`. On Linux,
+the path to the device will typically be in the form of `/dev/sdX` (where X is a
+number) for USB devices, `/dev/mmcblkX` for SD cards, or other variations
+depending on the device. You can use the model and size (`7.5GiB` above, after
+the path) to identify the device if you're not sure what path it will have.
 
-Next, ensure the device is not currently mounted:
+Once you've identified the device you'll use, ensure it's not mounted by
+unmounting it with [umount(8)](https://man.voidlinux.org/man8/umount.8):
 
 ```
 # umount /dev/sdX
+umount: /dev/sdX: not mounted.
 ```
 
-Write the live image to the device:
+### Write the Live Image
+
+The [dd(1)](https://man.voidlinux.org/man1/dd.1) command can be used to copy a
+live image to a storage device. Using dd, write the live image to the device:
 
 > **Warning**: this will destroy any data currently on the referenced device.
 > Exercise caution.
 
 ```
 # dd bs=4M if=/path/to/void-live-ARCH-DATE-VARIANT.iso of=/dev/sdX
+90+0 records in
+90+0 records out
+377487360 bytes (377 MB, 360 MiB) copied, 0.461442 s, 818 MB/s
 ```
 
-Ensure all data is flushed before disconnecting the device:
+dd won't print anything until it's completed (or if it failed), so depending on
+the device, this can take a few minutes or longer.
+
+Finally, ensure all data is flushed before disconnecting the device:
 
 ```
 $ sync
 ```
 
-## Create a bootable USB drive or SD card on Windows
-
-The [USBWriter](https://sourceforge.net/projects/usbwriter/) program is the only
-recommended method of creating a bootable drive on Windows. Other programs may
-mangle the data and make the drive ultimately unable to boot.
+The number of records, amount copied, and rates will all vary depending on the
+device and the live image you chose.
 
 ## Burning to a CD or DVD
 
@@ -54,4 +73,3 @@ CD or DVD. The following free software applications are available
 
 > Note: with a CD or DVD, live sessions will be less responsive than with a USB
 > or hard drive.
-


### PR DESCRIPTION
This is an editing pass over the installation documentation. All
content should be semantically the same, but hopefully written in such
a way that it's a little bit of a better read.

Summary of content changes:

- Added a howtoread chapter. Currently just a single page, no
  sub-documents. Any decisions about formatting that communicate things
  to a user should be explained here.

- Removed quotes around most uses of "flavor" -- it's fine to direct
  attention to it once or twice, but it's really not necessary to put
  quotes around every reference to a flavor image.

- Split up the verifying integrity write-up into checksums / GPG so
  that it's in smaller chunks overall (should make it easier to know
  when the reader has made progress).

- Split up the prep.md USB / SD card section into two parts (identify
  your device and write the image). Also added example output to
  commands where possible.