### PR TITLE
about: change init from section 1 to 8

### DIFF
--- a/src/about/index.md
+++ b/src/about/index.md
@@ -24,7 +24,7 @@ and time again that they are dedicated to the security, quality, and
 maintainability of this critical library.
 
 A final distinguishing characteristic of Void is our choice of program for
-`init(1)`. Void Linux boots with smarden runit, a very small service supervision
+`init(8)`. Void Linux boots with smarden runit, a very small service supervision
 system. The small codebase of runit allows us to support a second libc without
 significant effort, something that would not have been possible with other
 options available today. You can learn more about runit on its website


### PR DESCRIPTION
I believe `init(1)` on the *about* page should instead be `init(8)`. That's the section it is for runit's manpage and as far as I know for the traditional SysV-init as well.

Another thing that might be nice but I didn't change in this PR would be a link to the [wikipedia page for init](https://en.wikipedia.org/wiki/Init) or something similar. The passage mentions `init` as if the reader already knows what that means.