### PR TITLE
mirrors/changing.md: fixed mirror syntax to be consistent

### DIFF
--- a/src/maintenance/repositories/mirrors/changing.md
+++ b/src/maintenance/repositories/mirrors/changing.md
@@ -10,7 +10,7 @@ To modify mirror URLs cleanly, copy all the repository configuration files to to
 ```
 # mkdir -p /etc/xbps.d
 # cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
-# sed -i 's|https://alpha.de.repo.voidlinux.org/current|<repository>|g' /etc/xbps.d/*-repository-*.conf
+# sed -i 's|https://alpha.de.repo.voidlinux.org|<repository>|g' /etc/xbps.d/*-repository-*.conf
 ```
 
 After changing the URLs, you must synchronize xbps with the new mirrors:


### PR DESCRIPTION
I was trying out different mirrors this morning and realized that our official mirror URLs do not include 'current' in the URL, so if you were to substitute them into this regex, it would break.

I am starting to wonder if this usage is something we want to have in our documentation, but for now I want to make sure it works!