### PR TITLE
base-requirements: modify minimum storage requirements

### DIFF
--- a/src/installation/base-requirements.md
+++ b/src/installation/base-requirements.md
@@ -5,9 +5,9 @@ following minimums for most installations:
 
 | Architecture | CPU              | RAM  | Storage |
 |--------------|------------------|------|---------|
-| x86_64-glibc | EM64T            | 96MB | 350MB   |
-| x86_64-musl  | EM64T            | 96MB | 350MB   |
-| i686-glibc   | Pentium 4 (SSE2) | 96MB | 350MB   |
+| x86_64-glibc | EM64T            | 96MB | 700MB   |
+| x86_64-musl  | EM64T            | 96MB | 600MB   |
+| i686-glibc   | Pentium 4 (SSE2) | 96MB | 700MB   |
 
 > Note: Flavor installations require more resources. How much more depends on
 > the flavor.


### PR DESCRIPTION
I did a little test installing a base glibc system and a musl system into a folder, just to see how much space they take with just the `base-system` package group.

1. glibc used 675M
```
# sudo xbps-install -S -R https://repo.voidlinux.eu/current/ -r /tmp/void-glibc base-system
# du -sh /tmp/void-glibc
675M    /tmp/void-glibc/
```

2. musl used 561M
```
# sudo xbps-install -S -R https://repo.voidlinux.eu/current/musl/ -r /tmp/void-musl/ base-system
# du -sh /tmp/void-musl
561M    /tmp/void-musl/
```

So a bit higher than 350 lol

We should probably update these recommendations to reflect that. Not sure exactly how much above the true minimum we should set this recommendation, though. I'm open to input.