### PR TITLE
mirrors: add lysator mirror

### DIFF
--- a/src/maintenance/repositories/mirrors/list.md
+++ b/src/maintenance/repositories/mirrors/list.md
@@ -12,11 +12,13 @@
 
 ## Tier 2 mirrors
 
-| Repository                                   | Location        |
-|----------------------------------------------|-----------------|
-| <http://mirror.aarnet.edu.au/pub/voidlinux/> | AU: Canberra    |
-| <http://ftp.swin.edu.au/voidlinux/>          | AU: Melbourne   |
-| <http://ftp.acc.umu.se/mirror/voidlinux.eu/> | EU: Sweden      |
-| <https://mirrors.dotsrc.org/voidlinux/>      | EU: Denmark     |
-| <http://www.gtlib.gatech.edu/pub/VoidLinux/> | USA: Atlanta    |
-| <https://void.webconverger.org>              | APAN: Singapore |
+| Repository                                                                             | Location        |
+|----------------------------------------------------------------------------------------|-----------------|
+| <http://mirror.aarnet.edu.au/pub/voidlinux/>                                           | AU: Canberra    |
+| <http://ftp.swin.edu.au/voidlinux/>                                                    | AU: Melbourne   |
+| <http://ftp.acc.umu.se/mirror/voidlinux.eu/>                                           | EU: Sweden      |
+| <https://mirrors.dotsrc.org/voidlinux/>                                                | EU: Denmark     |
+| <http://www.gtlib.gatech.edu/pub/VoidLinux/>                                           | USA: Atlanta    |
+| <https://void.webconverger.org>                                                        | APAN: Singapore |
+| <http://ftp.lysator.liu.se/pub/voidlinux/>                                             | EU: Sweden      |
+| <http://lysator7eknrfl47rlyxvgeamrv7ucefgrrlhk7rouv3sna25asetwid.onion/pub/voidlinux/> | EU: Sweden      |


### PR DESCRIPTION
This is a PR to add Lysator's FTP as a void-linux mirror.