### PR TITLE
ci/format.sh: remove `go version` which is redundant

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -6,7 +6,6 @@ curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master
 chmod +x ~/bin/gimme
 
 eval "$(gimme stable)"
-go version
 
 go get github.com/bobertlo/vmd/cmd/vmdfmt
 


### PR DESCRIPTION
This is just a small thing, but bugs me whenever I look at the travis log.