### PR TITLE
general.css: revert #sidebar font-size to previous value

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -129,6 +129,7 @@ table tbody tr:nth-child(2n) {
 #sidebar {
 	padding: .5em;
 	background: #fafafa;
+	font-size: 0.875em;
 }
 #sidebar ol {
 	list-style: none;


### PR DESCRIPTION
I noticed the sidebar font got larger. I just found the old size from the mdbook default and put it in. It looks a little crowded with the larger font.