### PR TITLE
add skip to content link

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -121,6 +121,19 @@ table tbody tr:nth-child(2n) {
 	background: #000;
 }
 
+#skip-to-content {
+	position: absolute;
+	left: -999px;
+	top: -999px;
+}
+
+#skip-to-content:active,
+#skip-to-content:focus {
+	position: relative;
+	left: 0;
+	top: 0;
+}
+
 /* sidebar  */
 
 .sidebar-hidden #sidebar {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -35,6 +35,7 @@
 		<header>
 			<nav id="void-nav">
 				<ul>
+					<li><a id="skip-to-content" tabindex="1" href="#content">Skip to content</a></li>
 					<li>
 						<button id="sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
 							<i class="fa fa-bars"></i>
@@ -105,6 +106,7 @@
 				<main>
 					{{{ content }}}
 				</main>
+
 				<nav id="nav-wide-wrapper" aria-label="Page navigation">
 					{{#previous}}
 						<a href="{{ path_to_root }}{{link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">


### PR DESCRIPTION
Add a hidden "skip to content" link like github has as the first  tab index.
If tab is used and the link becomes focused/active it will be visible and allows a user to skip over the menu and the sidebar to reach the content easier.

![skip-to-content](https://user-images.githubusercontent.com/2813151/52441078-0dae8600-2b20-11e9-9a68-1906a2e839db.png)
