### PR TITLE
config/bluetooth: add bluetooth page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,6 +32,7 @@
       - [ALSA](./config/media/alsa.md)
       - [PulseAudio](./config/media/pulseaudio.md)
       - [sndio](./config/media/sndio.md)
+   - [Bluetooth](./config/bluetooth.md)
    - [Printing](./config/print/index.md)
       - [Installing Printing Packages](./config/print/install.md)
       - [Configuring A New Printer](./config/print/config.md)

--- a/src/config/bluetooth.md
+++ b/src/config/bluetooth.md
@@ -1,0 +1,86 @@
+# Bluetooth
+
+Ensure the bluetooth controller is not blocked. Use `rfkill` to check whether
+there are any blocks and to remove soft blocks. If there is a hard block, there
+is likely either a physical hardware switch or an option in the BIOS to enable
+the bluetooth controller.
+
+```
+$ rfkill
+ID TYPE     DEVICE      SOFT      HARD
+0 wlan      phy0   unblocked unblocked
+1 bluetooth hci0     blocked unblocked
+
+# rfkill unblock bluetooth
+```
+
+## Installation
+
+Install the `bluez` package.
+
+```
+# xbps-install -S bluez
+```
+
+Enable the `bluetoothd` and `dbus` services.
+
+```
+# ln -s /etc/sv/dbus /var/service
+# ln -s /etc/sv/bluetoothd /var/service
+```
+
+Add your user to the `bluetooth` group and restart the `dbus` service, or simply
+reboot the system. Note that restarting the `dbus` service may kill processes
+making use of it.
+
+```
+# usermod -a -G bluetooth $USER
+# sv restart dbus
+```
+
+> Note: To use an audio device such as a wireless speaker or headset, ALSA users
+> need to install the `bluez-alsa` package, while
+> [PulseAudio](./media/pulseaudio.md) users do not need any additional software.
+
+## Usage
+
+Manage bluetooth connections and controllers using `bluetoothctl`. It uses a
+command line interface; to find out what commands are available, enter `help`.
+To exit, enter `exit` or `quit`.
+
+```
+$ bluetoothctl
+
+[bluetooth]# help
+Menu main:
+Available commands:
+-------------------
+advertise             Advertise Options Submenu
+scan                  Scan Options Submenu
+gatt                  Generic Attribute Submenu
+list                  List available controllers
+show [ctrl]           Controller information
+select <ctrl>         Select default controller
+devices               List available devices
+paired-devices        List paired devices
+...
+```
+
+Consult the [Arch Wiki](https://wiki.archlinux.org/index.php/Bluetooth#Pairing)
+page for an example on how to pair a device.
+
+`bluetoothctl` also accepts taking commands from stdin.
+
+```
+$ echo "devices" | bluetoothctl
+Agent registered
+[bluetooth]# devices
+Device XX:XX:XX:XX:XX:XX Mouse
+Device XX:XX:XX:XX:XX:XX Keyboard
+Device XX:XX:XX:XX:XX:XX Speaker
+Device XX:XX:XX:XX:XX:XX Headset
+```
+
+## Configuration
+
+The main configuration file is `/etc/bluetooth/main.conf`.


### PR DESCRIPTION
I've started on the bluetooth page. Feedback appreciated.

Some extra thoughts:

1. In order for unpriviledged users to use `bluetoothctl`, they must be in either the `bluetooth` group or the `lp` group. The Void Wiki says to use the former while the Arch Wiki says to use the latter. I really don't know much about these two groups and by extension which would be the correct one to suggest to users.

Neither the Arch or Debian wikis mention the `bluetooth` group, but both briefly mention the `lp` group.

[Arch](https://wiki.archlinux.org/index.php/users_and_groups#System_groups):
> Access to parallel port devices (printers and others).

[Debian](https://wiki.debian.org/SystemGroups):
> Members of this group can enable and use printers. (The user lp is not used anymore.)

-------------------------------------------

2. I included the following:

> Note: To use an audio device such as a wireless speaker or headset, you must also use the PulseAudio sound server.

Though, this is only an assumption I made based on my limited experience. If anyone knows whether you can use bluetooth audio devices with `sndio` or plain `ALSA` then please chime in!