### PR TITLE
A trick to solve issue with groups in per-user services

### DIFF
--- a/src/config/services/user-services.md
+++ b/src/config/services/user-services.md
@@ -26,3 +26,15 @@ One important caveat: if any services you have need group permissions instead of
 just your user permissions, you will want to append those groups in a colon
 separated list to your username, such as `/etc/sv/anon:void1:void2:void3/run`
 instead of just `/etc/sv/anon/run`.
+
+If you want to append all users groups as in `/etc/group`, groups utility can
+solve this for you:
+
+```
+username="$UID"
+
+# GNU coreutils
+usergroups="$( groups "$username" | tr -s ' ' ':' )"
+# other implementations
+usergroups="$UID:$( groups "$username" | tr ' ' ':' )"
+```


### PR DESCRIPTION
Hi. I'm not sure how much wiki-like you want these docs to be (there are not many pull requests yet), so if this doesn't fit the style feel free to throw this away.

This is just a trick I use to make my user services use all of my users groups.

Also, why do you use the UID variable name for user name? Usually USER variable is used for text username and UID is for users numerical id. Here I used intermediate variable username to try and prevent any colisions.