### PR TITLE
Update wpa_supplicant.md

### DIFF
--- a/src/config/network/wpa_supplicant.md
+++ b/src/config/network/wpa_supplicant.md
@@ -85,5 +85,5 @@ To enable the [wpa_supplicant(8)](https://man.voidlinux.org/wpa_supplicant.8)
 service.
 
 ```
-# ln -s /etc/sv/wpa_supplicant /var/service
+# ln -s /etc/sv/wpa_supplicant /var/service/
 ```


### PR DESCRIPTION
A slash has been omitted at the end of the "ln -s" command.