### PR TITLE
Fixed a link typo in the installation guide to post-install page

### DIFF
--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -124,5 +124,5 @@ successfully, you can reboot into your new Void Linux install!
 
 ## Post installation
 
-See the [Post Installation](../../config/postinstall.md) guide for some tips on
+See the [Post Installation](../../config/post-install.md) guide for some tips on
 setting up your new system.


### PR DESCRIPTION
In <https://docs.voidlinux.org/installation/live-images/guide.html>, the Post Installation guide link is a 404. Fixed that link typo.