### PR TITLE
Description of removing default kernels

### DIFF
--- a/src/config/kernel.md
+++ b/src/config/kernel.md
@@ -41,6 +41,15 @@ that is currently booted
 # vkpurge rm all
 ```
 
+## Completely remove kernel series marked as default
+
+To remove default kernel series execute
+
+```
+# echo "ignorepkg=linux4.19" | sudo tee -a /etc/xbps.d/10-ignore.conf; xbps-remove linux4.19
+```
+Make sure you have installed and tested desired kernel series.
+
 ## Kernel modules
 
 ### Loading kernel modules at boot

--- a/src/config/kernel.md
+++ b/src/config/kernel.md
@@ -46,7 +46,7 @@ that is currently booted
 To remove default kernel series execute
 
 ```
-# echo "ignorepkg=linux4.19" | sudo tee -a /etc/xbps.d/10-ignore.conf; xbps-remove linux4.19
+# echo "ignorepkg=linux4.19" | tee -a /etc/xbps.d/10-ignore.conf; xbps-remove linux4.19
 ```
 Make sure you have installed and tested desired kernel series.
 


### PR DESCRIPTION
Since its impossbile to remove default kernel series with simple xbps-remove -f command, proposed option should be added to free additional space, time and, as a bonus, stress to SSD drives.