### PR TITLE
README.md: add building/serving instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Welcome to the Void documentation. This repository contains the source data
 behind <https://docs.voidlinux.org/>. Contributing to this repository follows
 the same protocol as the packages tree.
+
+## Contributing
+
+See the [Submitting Changes](https://docs.voidlinux.org/contributing/void-docs/submitting.html) page on the docs.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -65,3 +65,4 @@
    - [Usage Statistics](./contributing/usage-statistics.md)
    - [Void Docs](./contributing/void-docs/index.md)
       - [Style Guide](./contributing/void-docs/style-guide.md)
+      - [Submitting Changes](./contributing/void-docs/submitting.md)

--- a/src/contributing/void-docs/submitting.md
+++ b/src/contributing/void-docs/submitting.md
@@ -1,0 +1,48 @@
+## Submitting Changes
+
+### Requirements
+
+To clone the repository and push changes
+[git(1)](https://man.voidlinux.org/git.1) is required, which is available as the
+`git` package.
+
+Building the Void Handbook locally requires
+[mdBook](https://rust-lang-nursery.github.io/mdBook/), which can be installed
+with the `mdBook` package on Void. At the root of the void-docs repository
+`mdbook serve` can be run to serve the docs on your localhost.
+
+### Forking
+
+To fork the repository a [github account](https://github.com/join) is needed.
+After the account is created follow github's
+[guide](https://help.github.com/en/articles/fork-a-repo) on setting up a fork.
+
+Clone the repository onto your computer, enter it, and create a new branch:
+
+```
+$ git clone https://github.com/YOUR_USERNAME/void-docs.git
+$ cd void-docs
+$ git checkout -b <BRANCH_NAME>
+```
+
+After editing the file(s), commit the changes and push them to the forked
+repository:
+
+```
+$ git add <EDITED_FILE(S)>
+$ git commit -m "<COMMIT_MESSAGE>"
+$ git push --set-upstream origin <BRANCH_NAME>
+```
+
+> The commit message should be in the form of `section: what was changed`
+
+Pull requests should only contain a single commit. If a change is made after the
+initial commit `git add` the changed files and then run `git commit --amend`.
+The updated commit will need to be force pushed: `git push --force`.
+
+If multiple commits are made they will need to be squashed into one with `git
+rebase -i HEAD~X` where X is the number of commits that need to be squashed. An
+editor will appear to choose which commits to squash. A second editor will
+appear to choose the commit message. See
+[git-rebase(1)](https://man.voidlinux.org/git-rebase.1) for more information.
+The updated commit will need to be force pushed: `git push --force`.


### PR DESCRIPTION
The repository has nothing on how to setup a local version of the docs for testing.

A couple weeks ago I was looking at the docs and thinking about contributing but I couldn't find a way to serve the docs on my localhost.

Today I thought I mess around with it a bit and made a guess based on the description of the repo ("mdbook source for docs.voidlinux.org") and installed `mdBook` from the repositories and followed the instructions at [mdBook's repo](https://github.com/rust-lang-nursery/mdBook#usage) for running.

This PR will hopefully prevent future potential contributors from running into the same issue I did. The additions to the readme are based off of the ones in mdBook's readme.