### PR TITLE
Add note about handling pre-existing partition layout.

### DIFF
--- a/src/installation/live-images/partitions.md
+++ b/src/installation/live-images/partitions.md
@@ -6,6 +6,14 @@ process. When creating your new partition table you will need a partition for
 the root filesystem, along with a swap partition and possibly another partition
 or two to facilitate booting, if required.
 
+Note that if the disk has already been initialised, the top of the `cfdisk`
+screen will show the partition layout already present: `Label: dos` for the MBR
+scheme, `Label: gpt` for the GPT scheme. If you just want to erase the partition
+table before starting the installer, use `wipefs(8)`. Otherwise, you can run
+`cfdisk(8)` manually with the `-z` option to start with an uninitialised disk
+layout; `cfdisk` will prompt you for the label type before continuing to the
+main screen.
+
 The following sections will detail the options for partition configuration.
 
 ## BIOS system notes


### PR DESCRIPTION
i recently found [this section of the old wiki](https://wiki.voidlinux.org/Installation#Cfdisk_does_not_give_me_a_choice_of_partition_table_type) helpful, so would like this information added to the Handbook. :-)