### PR TITLE
Updated list of mirrors

### DIFF
--- a/src/xbps/repositories/mirrors/list.md
+++ b/src/xbps/repositories/mirrors/list.md
@@ -2,24 +2,24 @@
 
 ## Tier 1 mirrors
 
-| Repository                                    | Location         |
-|-----------------------------------------------|------------------|
-| <http://alpha.de.repo.voidlinux.org>          | EU: Finland      |
-| <http://alpha.us.repo.voidlinux.org>          | USA: Kansas City |
-| <http://mirror.clarkson.edu/voidlinux/>       | USA: New York    |
-| <http://mirrors.servercentral.com/voidlinux/> | USA: Chicago     |
+| Repository                                     | Location         |
+|------------------------------------------------|------------------|
+| <https://alpha.de.repo.voidlinux.org/>         | EU: Finland      |
+| <https://alpha.us.repo.voidlinux.org/>         | USA: Kansas City |
+| <https://mirror.clarkson.edu/voidlinux/>       | USA: New York    |
+| <https://mirrors.servercentral.com/voidlinux/> | USA: Chicago     |
 
 ## Tier 2 mirrors
 
 | Repository                                                                             | Location          |
 |----------------------------------------------------------------------------------------|-------------------|
-| <http://mirror.aarnet.edu.au/pub/voidlinux/>                                           | AU: Canberra      |
-| <http://ftp.swin.edu.au/voidlinux/>                                                    | AU: Melbourne     |
-| <http://ftp.acc.umu.se/mirror/voidlinux/>                                              | EU: Sweden        |
+| <https://mirror.aarnet.edu.au/pub/voidlinux/>                                          | AU: Canberra      |
+| <https://ftp.swin.edu.au/voidlinux/>                                                   | AU: Melbourne     |
+| <https://ftp.acc.umu.se/mirror/voidlinux/>                                             | EU: Sweden        |
 | <https://mirrors.dotsrc.org/voidlinux/>                                                | EU: Denmark       |
-| <http://www.gtlib.gatech.edu/pub/VoidLinux/>                                           | USA: Atlanta      |
-| <https://void.webconverger.org>                                                        | APAN: Singapore   |
+| <https://void.webconverger.org/>                                                       | APAN: Singapore   |
 | <https://youngjin.io/voidlinux/>                                                       | APAN: South Korea |
-| <http://ftp.lysator.liu.se/pub/voidlinux/>                                             | EU: Sweden        |
+| <https://ftp.lysator.liu.se/pub/voidlinux/>                                            | EU: Sweden        |
 | <http://lysator7eknrfl47rlyxvgeamrv7ucefgrrlhk7rouv3sna25asetwid.onion/pub/voidlinux/> | EU: Sweden        |
 | <https://mirror.yandex.ru/mirrors/voidlinux/>                                          | RU: Russia        |
+| <https://void.cijber.net/>                                                             | EU: Amsterdam, NL |


### PR DESCRIPTION
- Added https:// where available
- Added trailing slash to provide consistency
- Removed gatech mirror: outdated
- Added cijber mirror