### PR TITLE
Use svgs instead of font awesome

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -66,6 +66,13 @@ table tbody tr:nth-child(2n) {
 	background: #fafafa;
 }
 
+svg {
+	position: relative;
+	top: .125em;
+	width: 1em;
+	height: auto;
+}
+
 .hidden {
 	display: none;
 }
@@ -90,7 +97,7 @@ table tbody tr:nth-child(2n) {
 }
 #void-nav button,
 #void-nav label {
-	color: #fff;
+	fill: #fff;
 	height: 50px;
 	display: block;
 	line-height: 50px;
@@ -218,9 +225,7 @@ ul#searchresults span.teaser {
 	right: 15px;
 }
 .nav-chapters {
-	background: #fafafa;
-	color: #ccc;
-	font-size: 2.5em;
+	fill: #ccc;
 	text-align: center;
 	text-decoration: none;
 	display: block;
@@ -229,6 +234,12 @@ ul#searchresults span.teaser {
 }
 .nav-chapters:hover {
 	text-decoration: none;
+	fill: #333
+}
+
+.nav-chapters svg {
+	margin: 0 auto;
+	width: 1.5em;
 }
 
 /* layout */
@@ -297,30 +308,4 @@ body {
 	#void-nav ul.right {
 		display: none;
 	}
-}
-
-@font-face {
-	font-family: 'FontAwesome';
-	src: url('/FontAwesome/fonts/fontawesome-webfont.eot?v=4.4.0');
-	src: url('/FontAwesome/fonts/fontawesome-webfont.eot?#iefix&v=4.4.0') format('embedded-opentype'),url('/FontAwesome/fonts/fontawesome-webfont.woff2?v=4.4.0') format('woff2'),url('/FontAwesome/fonts/fontawesome-webfont.woff?v=4.4.0') format('woff'),url('../fonts/fontawesome-webfont.ttf?v=4.4.0') format('truetype'),url('/FontAwesome/fonts/fontawesome-webfont.svg?v=4.4.0#fontawesomeregular') format('svg');
-	font-weight: normal;
-	font-style: normal
-}
-.fa {
-	display: inline-block;
-	font: normal normal normal 14px/1 FontAwesome;
-	font-size: inherit;
-	text-rendering: auto;
-}
-.fa-search:before {
-	content: "\f002"
-}
-.fa-navicon:before,.fa-reorder:before,.fa-bars:before {
-	content: "\f0c9"
-}
-.fa-angle-left:before {
-	content:"\f104"
-}
-.fa-angle-right:before {
-	content:"\f105"
 }

--- a/src/theme/css/print.css
+++ b/src/theme/css/print.css
@@ -49,6 +49,6 @@ pre, code {
     white-space: pre-wrap;
 }
 
-.fa {
+svg {
     display: none !important;
 }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -34,13 +34,17 @@
 					<li><a id="skip-to-content" tabindex="1" href="#content">Skip to content</a></li>
 					<li>
 						<button id="sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
-							<i class="fa fa-bars"></i>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+								<path d="M1 3v2h18V3zm0 8h18V9H1zm0 6h18v-2H1z"/>
+							</svg>
 						</button>
 					</li>
 				{{#if search_enabled}}
 					<li>
 						<button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">
-							<i class="fa fa-search"></i>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+								<path d="M7.5 13c3.04 0 5.5-2.46 5.5-5.5S10.54 2 7.5 2 2 4.46 2 7.5 4.46 13 7.5 13zm4.55.46C10.79 14.43 9.21 15 7.5 15 3.36 15 0 11.64 0 7.5S3.36 0 7.5 0C11.64 0 15 3.36 15 7.5c0 1.71-.57 3.29-1.54 4.55l6.49 6.49-1.41 1.41-6.49-6.49z"/>
+							</svg>
 						</button>
 					</li>
 				{{/if}}
@@ -105,13 +109,17 @@
 				<nav id="nav-wide-wrapper" aria-label="Page navigation">
 					{{#previous}}
 						<a href="{{ path_to_root }}{{link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
-							<i class="fa fa-angle-left"></i>
+							<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+								<path d="M4 10l9 9 1.4-1.5L7 10l7.4-7.5L13 1z"/>
+							</svg>
 						</a>
 					{{/previous}}
 
 					{{#next}}
 						<a href="{{ path_to_root }}{{link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
-							<i class="fa fa-angle-right"></i>
+							<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+								<path d="M7 1L5.6 2.5 13 10l-7.4 7.5L7 19l9-9z"/>
+							</svg>
 						</a>
 					{{/next}}
 				</nav>


### PR DESCRIPTION
This does two things:
1. Keeps the icons if you block remote fonts like in Firefox Focus (FA icons show up as unicode squares)
2. Decreases page size. I performed a quick test on the [Downloading Images](https://docs.voidlinux.org/installation/live-images/downloading.html) page using the network tab of Firefox's Devtools with the following results:
**With font awesome:**
_Hosted (docs.voidlinux.org):_
woff2: 816.92KB
 woff: 837.29KB
  ttf: 404 Error<br>
_Localhost (localhost:3000):_
woff2: 809.11KB
 woff: 829.50KB
  ttf: 404 Error<br>
**Without font awesome (localhost only):**
   svgs: 733.51KB*
no svgs: 733.66KB**<br>
\*: Uses my `svg` branch. No font awesome at all
\*\*: Uses my `master` branch with connections to the font awesome icons blocked

Visual difference: [Font Awesome](https://i.imgur.com/HWn0CJR.png) vs [SVG Icons](https://i.imgur.com/Z70y6HS.png) (imgur)

The SVG icons I used are from MediaWiki's [OOUI](https://github.com/wikimedia/oojs-ui) and are [MIT licensed](https://github.com/wikimedia/oojs-ui/blob/master/LICENSE-MIT). If required I can note that in the HTML code above each svg icon.