### PR TITLE
installation: remove guides stub

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,7 +10,6 @@
       - [Prepare Installation Media](./installation/live-images/prep.md)
       - [Partitioning Notes](./installation/live-images/partitions.md)
       - [Installation Guide](./installation/live-images/guide.md)
-   - [Guides](./installation/guides/index.md)
 - [Configuration](./config/index.md)
    - [Post Installation](./config/post-install.md)
    - [Services And Daemons](./config/services/index.md)

--- a/src/installation/guides/index.md
+++ b/src/installation/guides/index.md
@@ -1,4 +1,0 @@
-# Installation Guides
-
-Got weird hardware or an unusual setup? This is the section for guides about how
-to install Void on things that it doesn't usually like.


### PR DESCRIPTION
Now that the documentation is Live and we still do not have any content in this section I think we should remove it for now.