### PR TITLE
theme: Add cursor: pointer to .icon-button

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -73,6 +73,7 @@ table tbody tr:nth-child(2n) {
 .icon-button {
 	border: none;
 	background: none;
+	cursor: pointer;
 	padding: 1em;
 }
 


### PR DESCRIPTION
The sidebar-toggle didn't have pointer-style cursor, even though it's a clickable element. I imagine all `.icon-button` elements should have this, so I stuck it there.