### PR TITLE
config/xorg/session-management.md: update section about ConsoleKit2

### DIFF
--- a/src/config/xorg/session-management.md
+++ b/src/config/xorg/session-management.md
@@ -3,11 +3,20 @@
 Session and seat management is not necessary for every setup, it is used to
 provide device access on the fly for the currently active user session.
 
-For desktop environments like Gnome, [elogind](#elogind) is necessary.
+Please note that [ConsoleKit2](#ConsoleKit2) is virtually unmaintained upstream and is thus no longer the default session and seat manager in Void Linux. If you are having issues with it, the recommended way is to remove [ConsoleKit2](#ConsoleKit2) and install [elogind](#elogind) instead. [ConsoleKit2](#ConsoleKit2) can still be used but requires manual setup of policykit rules to achieve full functionality. For desktop environments like Gnome, [elogind](#elogind) is necessary in any case.
+
+## elogind
+
+[elogind(8)](https://man.voidlinux.org/elogind.8) is a standalone version of
+systemd-logind, a service to manage user logins. Install the `elogind` package:
+
+```
+# xbps-install -S elogind
+```
 
 ## ConsoleKit2
 
-Install `ConsoleKit2` and activate its service. Ensure bothe the `dbus` and the
+Install `ConsoleKit2` and activate its service. Ensure both the `dbus` and the
 `cgmanager` services are activated too.
 
 ```
@@ -44,11 +53,4 @@ fi
 exec $STARTUP <window manager>
 ```
 
-## elogind
-
-[elogind(8)](https://man.voidlinux.org/elogind.8) is a standalone version of
-systemd-logind, a service to manage user logins. Install the `elogind` package:
-
-```
-# xbps-install -S elogind
-```
+If any functionality that is controlled by policykit  still not available after setting up ConsoleKit2, you need to place rules in `/etc/polkit-1/rules.d` to allow access by your user or group. This may be necessary for instance to allow shutdown and reboot, mounting and unmounting of disks via udisks2 or using the NetworkManager applet in your desktop environment.


### PR DESCRIPTION
clarify its current status and indicate that manual setup of policykit rules
may be necessary