### PR TITLE
config/date-time: fix a broken internal link

### DIFF
--- a/src/config/date-time.md
+++ b/src/config/date-time.md
@@ -33,7 +33,7 @@ Protocol](https://en.wikipedia.org/wiki/Network_Time_Protocol) (NTP).
 Void provides packages for three NTP daemons: NTP, OpenNTPD and Chrony.
 
 Once you have installed an NTP daemon, you can [enable the
-service](../runit/managing.md).
+service](../config/services/managing.md).
 
 ### NTP
 


### PR DESCRIPTION
The link to the "Managing Services" section on this page is broken. It should have been `../config/runit/managing.md` anyway, but as it seems like the "Runit" section was merged with "Services" anyway, `../config/services/managing.md` is now the correct destination.