### PR TITLE
Add 'Users and groups' section.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,6 +12,7 @@
       - [Installation Guide](./installation/live-images/guide.md)
 - [Configuration](./config/index.md)
    - [Post Installation](./config/post-install.md)
+   - [Users and groups](./config/users-and-groups.md)
    - [Services And Daemons](./config/services/index.md)
       - [Managing Services](./config/services/managing.md)
       - [Configuring Services](./config/services/configuring.md)

--- a/src/config/users-and-groups.md
+++ b/src/config/users-and-groups.md
@@ -1,0 +1,39 @@
+# Users and groups
+
+## Default groups
+
+Void Linux defines a number of groups by default.
+
+| Group      | Description                                                   |
+|------------|---------------------------------------------------------------|
+| `root`     | Complete access to the system.                                |
+| `bin`      | Unused - present for historical reasons.                      |
+| `sys`      | Unused - present for historical reasons.                      |
+| `kmem`     | Ability to read from `/dev/mem` and `/dev/port`.              |
+| `wheel`    | Elevated privileges for specific system administration tasks. |
+| `tty`      | Access to TTY-like devices:                                   |
+|            | `/dev/tty*`, `/dev/pts*`, `/dev/vcs*`.                        |
+| `tape`     | Access to tape devices.                                       |
+| `daemon`   | System daemons that need to write to files on disk.           |
+| `floppy`   | Access to floppy drives.                                      |
+| `disk`     | Raw access to `/dev/sd*` and `/dev/loop*`.                    |
+| `lp`       | Access to printers.                                           |
+| `dialout`  | Access to serial ports.                                       |
+| `audio`    | Access to audio devices.                                      |
+| `video`    | Access to video devices.                                      |
+| `utmp`     | Ability to write to `/var/run/utmp`, `/var/log/wtmp`          |
+|            | and `/var/log/btmp`.                                          |
+| `adm`      | Unused - present for historical reasons. This group was       |
+|            | traditionally used for system monitoring, such as viewing     |
+|            | files in `/var/log`.                                          |
+| `cdrom`    | Access to CD devices.                                         |
+| `optical`  | Access to DVD/CD-RW devices.                                  |
+| `mail`     | Used by some mail packages, e.g. `dma`.                       |
+| `storage`  | Access to removable storage devices.                          |
+| `scanner`  | Ability to access scanners.                                   |
+| `network`  | Unused - present for historical reasons.                      |
+| `kvm`      | Ability to use KVM for virtual machines, e.g. via QEMU.       |
+| `input`    | Access to input devices: `/dev/mouse*`, `/dev/event*`.        |
+| `nogroup`  | System daemons that don't need to own any files.              |
+| `users`    | Ordinary users.                                               |
+| `xbuilder` | To use xbps-uchroot(1) with `xbps-src`.                       |


### PR DESCRIPTION
Initial draft to address #121, for feedback.

This draft is based on a combination of information on the Debian wiki, the Arch wiki, and calls to `find / -group`. :-) The 'Description' field for `mail` has text in square brackets to indicate that i'm particularly unsure about it, but hopefully the other descriptions aren't too far off-base. 