### PR TITLE
Add "musl" section.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,6 +12,7 @@
       - [Partitioning Notes](./installation/live-images/partitions.md)
       - [Installation Guide](./installation/live-images/guide.md)
 - [Configuration](./config/index.md)
+   - [musl](./config/musl.md)
    - [Post Installation](./config/post-install.md)
    - [Services And Daemons](./config/services/index.md)
       - [Managing Services](./config/services/managing.md)

--- a/src/config/musl.md
+++ b/src/config/musl.md
@@ -1,0 +1,52 @@
+# musl
+
+[musl](https://musl.libc.org/) is a libc implementation which strives to be
+lightweight, fast, simple, and correct.
+
+Void officially supports musl by using it in its codebase for all target
+platforms (although binary packages are not available for i686). Additionally,
+all compatible packages in our official repositories are available with
+musl-linked binaries in addition to their glibc counterparts.
+
+Currently, there are nonfree and debug subrepositories for musl, but no multilib
+subrepo.
+
+## Incompatible software
+
+Musl practices very strict and minimal standard compliance. Many commonly used
+platform-specific extensions are not present. Because of this, it is common for
+software to need modification to compile and/or function properly. Void
+developers work to patch such software and hopefully get portability/correctness
+changes accepted into the upstream projects.
+
+Proprietary software rarely supports non-glibc libc implementations, although
+sometimes these applications are available as [flatpaks](https://flatpak.org/),
+which provide their own libc in the image.
+
+### glibc chroot
+
+Software requiring glibc can be run in a glibc chroot.
+
+Create a directory that will contain the chroot, and install a base system in it
+via the `base-voidstrap` package. If network access is required, copy
+`/etc/resolv.conf` into the chroot; `/etc/hosts` may need to be copied as well.
+
+Several directories then need to be mounted as follows:
+
+```
+# mount -t proc none <chroot_dir>/proc
+# mount -t sysfs none <chroot_dir>/sys
+# mount --rbind /dev <chroot_dir>/dev
+# mount --rbind /run <chroot_dir>/run
+```
+
+Use [chroot(1)](https://man.voidlinux.org/chroot.1) to change to the new root,
+then run glibc programs as usual. Once you've finished using it, unmount the
+chroot using [umount(8)](https://man.voidlinux.org/umount.8).
+
+#### PRoot
+
+An alternative to the above is [proot(1)](https://man.voidlinux.org/proot.1), a
+user-space implementation of chroot, mount --bind, and binfmt_misc. By
+installing the `proot` package, unprivileged users can utilise a chroot
+environment.

--- a/src/installation/base-requirements.md
+++ b/src/installation/base-requirements.md
@@ -14,6 +14,9 @@ following minimums for most installations:
 
 Void is not available for i386, i486, or i586 architectures.
 
+Before installing musl Void, please read [the "musl" section](../config/musl.md)
+of this Handbook, so that you are aware of software incompatibilities.
+
 It is highly recommended to have a network connection available during install
 to download updates, but this is not required. ISO images contain installation
 data on-disc and can be installed without network connectivity.


### PR DESCRIPTION
Initial draft to address #130, for feedback.

i wasn't sure where to put this section in the Handbook, so i've just ended up putting it under the "Configuration" section. i've also added a link to this section from the "Base Requirements" page, with the idea of making people aware that a musl system might not be appropriate for their needs.

Also, would it be correct to say that those who need locale support should use glibc Void, rather than musl Void? (Locale support is certainly one of the reasons i use glibc rather than musl.)