### PR TITLE
config/wayland: add page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -39,6 +39,7 @@
       - [NVIDIA Optimus](./config/graphics/optimus.md)
    - [Xorg](./config/xorg/index.md)
       - [Session Management](./config/xorg/session-management.md)
+   - [Wayland](./config/wayland.md)
    - [Multimedia](./config/media/index.md)
       - [ALSA](./config/media/alsa.md)
       - [PulseAudio](./config/media/pulseaudio.md)

--- a/src/config/wayland.md
+++ b/src/config/wayland.md
@@ -1,0 +1,92 @@
+# Wayland
+
+This section details the manual installation and configuration of Wayland
+compositors and related services and utilities.
+
+## Installation
+
+Unlike [Xorg](./xorg/index.md), Wayland implementations combine the display
+server, the window manager and the compositor in a single application.
+
+### Desktop Environments
+
+Both GNOME and KDE Plasma have Wayland sessions. For GNOME, Wayland is already
+the default session, while Plasma still has a few issues to iron out, so their
+default remains a Xorg session. While running these desktop environments,
+applications built with Gtk+ will automatically choose the Wayland backend, but
+Qt applications might require the proper environment variable in GNOME. This is
+explained [below](#native-applications).
+
+### Stand-alone compositors
+
+Void Linux currently packages the following Wayland compositors:
+
+- Weston: reference compositor for Wayland
+- Sway: an i3-compatible Wayland compositor
+- Wayfire: 3D Wayland compositor
+- Cage: a Wayland kiosk
+
+### Video drivers
+
+KDE Plasma has an implementation for the proprietary NVIDIA API used for
+Wayland. The other Wayland compositors require open source drivers that
+implement EGL. The main driver for this purpose is provided by the `mesa-dri`
+package. The [graphics section](./graphics/index.md) has more details for
+setting up graphics in different systems.
+
+### Native applications
+
+Qt5 based applications require the installation of the `qt5-wayland` package and
+setting the environment variable `QT_QPA_PLATFORM=wayland-egl` to enable their
+Wayland backend. Some KDE specific applications might also require the
+installation of the `kwayland` package. Gtk+ applications should do it
+automatically, but setting `GDK_BACKEND=wayland` can force the Wayland backend
+(however, this can break applications such as Chromium).
+
+#### Web browsers
+
+Mozilla Firefox ships with a Wayland backend which is disabled by default.
+Launching Firefox with `MOZ_ENABLE_WAYLAND=1` is required to enable it.
+
+The Midori browser, which has a Gtk+ interface, should also work on Wayland.
+
+Qt5 based browsers, such as qutebrowser, also work on Wayland.
+
+#### Terminal emulators
+
+- Alacritty (it's the standard terminal emulator for Sway)
+- Kitty
+- Sakura
+
+#### Media applications
+
+Both mpv and VLC work on Wayland, with hardware acceleration (if available and
+enabled).
+
+For image viewing, imv works natively on Wayland.
+
+#### General desktop utilities
+
+- For screenshots: `grim` and `slurp`. `slurp` is required to define a geometry.
+- For accessing the clipboard: `wl-clipboard`.
+- For displaying notifications (notification daemon): `mako`.
+- For launching applications:
+   - wofi
+   - bemenu
+   - dmenu-wayland
+
+#### Running X applications inside Wayland
+
+If an application still doesn't support Wayland, it can still be run in a
+Wayland context. XWayland is an X server that bridges this gap for most Wayland
+compositors, and is installed as a dependency for most of them. Its package is
+`xorg-server-xwayland`. For Weston, the correct package is `weston-xwayland`.
+
+## Configuration
+
+The Wayland API uses the `XDG_RUNTIME_DIR` environment variable to determine the
+directory for the Wayland socket. In order to securely set this variable, you
+need the `elogind` service installed and enabled as your session manager.
+
+It is also possible that some applications use the `XDG_SESSION_TYPE`
+environment variable in some way, which requires that you set it to `wayland`.


### PR DESCRIPTION
Add a Wayland page, loosely based on what's available on the wiki. I can add/remove/correct information according to suggestions and opinions here.