### PR TITLE
pulseaudio: Tidy section.

### DIFF
--- a/src/config/media/pulseaudio.md
+++ b/src/config/media/pulseaudio.md
@@ -1,27 +1,17 @@
 # PulseAudio
 
-PulseAudio depends on a `dbus` system daemon, make sure its enabled.
-
-```
-# xbps-install -S alsa-utils pulseaudio
-# ln -s /etc/sv/dbus /var/service/
-```
+PulseAudio depends on a `dbus` system daemon. Make sure the `dbus` service is
+enabled.
 
 For applications which use ALSA directly and don't support PulseAudio, the
-`alsa-plugins-pulseaudio`package can be installed to make them use PulseAudio
-through ALSA.
+`alsa-plugins-pulseaudio` package can make them use PulseAudio through ALSA.
 
-```
-# xbps-install -S alsa-plugins-pulseaudio
-```
-
-The PulseAudio package comes with a services file, which is not necessary in
-most setups and the PulseAudio maintainers
+The PulseAudio package comes with a service file, which is not necessary in most
+setups - the PulseAudio maintainers
 [discourage](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/)
 using a system-wide setup. Instead, PulseAudio will automatically start when
 needed.
 
-There are different methods that work with PulseAudio to allow access to the
-audio devices, the simplest one is to just the `audio` group alternatively you
-can use a session manager, like [elogind](#elogind) or
-[ConsoleKit2](#consolekit2).
+There are several methods of allowing PulseAudio to access to audio devices. The
+simplest one is to make use of the `audio` group. Alternatively, you can use a
+session manager, like `elogind`.


### PR DESCRIPTION
This PR removes unnecessary command samples, removes outdated links, and improves the prose.

Further to a comment made by a user on #voidlinux, i feel the last paragraph could do with some expansion: what does one actually need to do with the `audio` group to allow PulseAudio to access audio devices?