### PR TITLE
wpa_supplicant: Reorganise section.

### DIFF
--- a/src/config/network/wpa_supplicant.md
+++ b/src/config/network/wpa_supplicant.md
@@ -1,20 +1,54 @@
 # wpa_supplicant
 
-The `wpa_supplicant` package is installed by default on the base system and
-includes utilities to configure wireless interfaces and, more specifically, to
-handle wireless security protocols.
+The `wpa_supplicant` package is installed by default on the base system. It
+includes utilities to configure wireless interfaces and handle wireless security
+protocols.
 
 [wpa_supplicant(8)](https://man.voidlinux.org/wpa_supplicant.8) is a daemon that
 manages wireless interfaces based on
 [wpa_supplicant.conf(5)](https://man.voidlinux.org/wpa_supplicant.conf.5)
-configuration files.
-[wpa_passphrase(8)](https://man.voidlinux.org/wpa_passphrase.8) and
-[wpa_cli(8)](https://man.voidlinux.org/wpa_cli.8) are frontends to manage the
-configuration files and the running service.
+configuration files. An extensive overview of configuration options, including
+examples, can be found in
+`/usr/share/examples/wpa_supplicant/wpa_supplicant.conf`.
 
-## WEP configuration
+[wpa_passphrase(8)](https://man.voidlinux.org/wpa_passphrase.8) helps create
+pre-shared keys for use in configuration files.
+[wpa_cli(8)](https://man.voidlinux.org/wpa_cli.8) provides a CLI for managing
+the `wpa_supplicant` daemon.
 
-For WEP configuration, you can just add the following lines to your device's
+## WPA-PSK
+
+To use WPA-PSK, generate a pre-shared key with
+[wpa_passphrase(8)](https://man.voidlinux.org/wpa_passphrase.8) and append the
+output to the relevant `wpa_supplicant.conf` file:
+
+```
+# wpa_passphrase <MYSSID> <passphrase> >> /etc/wpa_supplicant/wpa_supplicant-<device_name>.conf
+```
+
+The resulting file should look something like:
+
+```
+# Default configuration file for wpa_supplicant.conf(5).
+
+ctrl_interface=/run/wpa_supplicant
+ctrl_interface_group=wheel
+eapol_version=1
+ap_scan=1
+fast_reauth=1
+update_config=1
+
+# Add your networks here.
+network={
+    ssid="MYSSID"
+    #psk="YOUR AP KEY"
+    psk=a8c34100ab4e5afac33cad7184d45a29ee0079001577d579bec6b74e4d7b5ac8
+}
+```
+
+## WEP
+
+For WEP configuration, add the following lines to your device's
 `wpa-supplicant.conf` :
 
 ```
@@ -37,65 +71,23 @@ network={
 }
 ```
 
-## WPA-PSK encryption
+### The wpa_supplicant service
 
-For `WPA-PSK` encryption, we must generate a `pre shared key` with
-[wpa_passphrase(8)](https://man.voidlinux.org/wpa_passphrase.8). To do so, run
-the following command:
+The `wpa_supplicant` runit script checks the following options in
+`/etc/sv/wpa_supplicant/conf`:
 
-```
-$ wpa_passphrase <MYSSID> <key>
-```
-
-You must append the output to your `wpa_supplicant.conf` file like so:
-
-```
-# wpa_passphrase <MYSSID> <key> >> /etc/wpa_supplicant/wpa_supplicant-<device_name>.conf
-```
-
-The resulting file should look something like this:
-
-```
-# Default configuration file for wpa_supplicant.conf(5).
-
-ctrl_interface=/run/wpa_supplicant
-ctrl_interface_group=wheel
-eapol_version=1
-ap_scan=1
-fast_reauth=1
-update_config=1
-
-# Add your networks here.
-network={
-    ssid="MYSSID"
-    #psk="YOUR AP KEY"
-    psk=a8c34100ab4e5afac33cad7184d45a29ee0079001577d579bec6b74e4d7b5ac8
-}
-```
-
-### Running wpa_supplicant under runit
-
-The runit scripts checks the following options in `/etc/sv/wpa_supplicant/conf`.
-
-- `OPTS`: Options to be passed to the service. (Overrides any other options!)
+- `OPTS`: Options to be passed to the service. Overrides any other options.
 - `CONF_FILE`: Path to file to be used for configuration.
-- `WPA_INTERFACE`: Interface to be matched (May contain a wildcard; Defaults to
-   all interfaces.)
+- `WPA_INTERFACE`: Interface to be matched. May contain a wildcard; defaults to
+   all interfaces.
 
 If no `conf` file is found, the service searches for the following files in
 `/etc/wpa_supplicant`:
 
-- `wpa_supplicant-<interface>.conf`: if found, these files are bound to the
+- `wpa_supplicant-<interface>.conf`: If found, these files are bound to the
    named interface.
-- `wpa_supplicant.conf`: if found, this file is loaded and binds to all other
+- `wpa_supplicant.conf`: If found, this file is loaded and binds to all other
    interfaces found.
-
-To enable the [wpa_supplicant(8)](https://man.voidlinux.org/wpa_supplicant.8)
-service.
-
-```
-# ln -s /etc/sv/wpa_supplicant /var/service/
-```
 
 ### Using wpa_cli
 


### PR DESCRIPTION
* Move WPA-PSK subsection before WEP section.
* Use 'passphrase' instead of 'key' in examples.
* Remove unneeded example re. enabling service.
* Add reference to `.../examples/.../wpa_supplicant.conf`.
* Improve prose.