### PR TITLE
rc-files: remove reference to TZ

### DIFF
--- a/src/config/rc-files.md
+++ b/src/config/rc-files.md
@@ -21,15 +21,6 @@ KEYMAP=fr
 For further details, refer to
 [loadkeys(1)](https://man.voidlinux.org/loadkeys.1).
 
-### TIMEZONE
-
-Specifies which timezone to use. Available timezones are listed in
-`/usr/share/zoneinfo`. For example:
-
-```
-TIMEZONE=Europe/Berlin
-```
-
 ### HARDWARECLOCK
 
 Specifies whether the hardware clock is set to UTC or local time.


### PR DESCRIPTION
The preferred way of setting localtime is by symlinking it to
/etc/localtime.

Related to https://github.com/void-linux/void-runit/pull/40