### PR TITLE
feat(config/security/apparmor): add section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -29,6 +29,7 @@
    - [Shell](./config/shell.md)
    - [Security](./config/security/index.md)
       - [hashboot](./config/security/hashboot.md)
+      - [AppArmor](./config/security/apparmor.md)
    - [Date and Time](./config/date-time.md)
    - [Kernel](./config/kernel.md)
    - [Network](./config/network/index.md)

--- a/src/config/security/apparmor.md
+++ b/src/config/security/apparmor.md
@@ -1,0 +1,18 @@
+# AppArmor
+
+AppArmor is a mandatory access control mechanism (like SELinux). It can
+constrain programs based on pre-defined or generated policy definitions.
+
+Void ships with some default profiles for several services, such as `dhcpcd` and
+`wpa_supplicant`. Container runtimes such as LXC and podman integrate with
+AppArmor for better security for container payloads.
+
+To use AppArmor on a system, one must:
+
+1. Install the `apparmor` package.
+2. Set the `APPARMOR` variable in `/etc/default/apparmor` to `enforce` or
+   `complain`.
+3. Set `apparmor=1 security=apparmor` on the kernel commandline.
+
+To accomplish the third step, consult [the documentation on how to modify the
+kernel cmdline](./../kernel.md#cmdline).


### PR DESCRIPTION
It is important to outline how to enable apparmor,
because there are a few steps and one is unique to Void.