### PR TITLE
[WIP] gnome: Add section.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -48,6 +48,7 @@
       - [Xorg](./config/graphical-session/xorg.md)
       - [Wayland](./config/graphical-session/wayland.md)
       - [Session Management](./config/graphical-session/session-management.md)
+      - [GNOME](./config/graphical-session/gnome.md)
    - [Multimedia](./config/media/index.md)
       - [ALSA](./config/media/alsa.md)
       - [PulseAudio](./config/media/pulseaudio.md)

--- a/src/config/graphical-session/gnome.md
+++ b/src/config/graphical-session/gnome.md
@@ -1,0 +1,30 @@
+# GNOME
+
+## Pre-installation
+
+Install the `dbus` package, ensure the `dbus` service is enabled, and reboot for
+the changes to take effect.
+
+## Installation
+
+Install the `gnome` package for a GNOME environment which includes GNOME
+applications.
+
+A minimal GNOME environment can be created by installing the `gnome-session`,
+`gdm` and `adwaita-icon-theme` packages. (Note, however, that not all GNOME
+features may be present or functional.) `gdm` defaults to providing a Wayland
+session, via the `mutter` window manager. For an Xorg session, install the
+`xorg` package, then select 'GNOME on Xorg' at the GDM login screen, or start
+`gnome-session` via `~/.xinitrc`.
+
+If you require [ZeroConf](http://www.zeroconf.org/) support, install the `avahi`
+package and enable the `avahi-daemon` service.
+
+## Display Manager
+
+To use a graphical display manager for logging in to GNOME, enable the `gdm`
+service. Test the `gdm` service before enabling it:
+
+```
+# sv once gdm
+```


### PR DESCRIPTION
Addresses #174.

This section reflects what i learned after a few hours experimenting with different scenarios in VMs:

* Merely enabling the `dbus` service is insufficient; after doing so, GNOME fails to start unless the system is first rebooted.
* The `gdm` package is required even for a `startx`-based session - again, without it, GNOME fails to start. Installing `gdm` pulls in a *lot* of dependencies, and i'm not sure which of them are strictly needed.
* If `adwaita-icon-theme` is not installed, no icons are displayed in the GNOME session, rendering it unusable.

Comments welcome!