### PR TITLE
book.toml: add linkcheck plugin

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,7 @@ title = "Void Linux Handbook"
 
 [output.html]
 theme = "src/theme"
+
+[output.linkcheck]
+follow-web-links = true
+exclude = [ "kernel.org", "\\.onion", "localhost", "hushan.tech" ]

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+echo "Installing mdbook-linkcheck"
+
+curl -sL -o ~/bin/linkcheck.tar.gz https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.5.1/mdbook-linkcheck-v0.5.1-x86_64-unknown-linux-gnu.tar.gz
+
+tar xvf ~/bin/linkcheck.tar.gz -C ~/bin
+
+echo "Checking links"
+
+~/bin/mdbook-linkcheck -s
+LINKCHECK=$?
+
 echo "Installing Go"
 
 curl -sL -o ~/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
@@ -35,5 +46,10 @@ if [ ! -z "$(git status --porcelain)" ] ; then
     git diff
     echo "Working directory not clean, files to be formatted:"
     git status
+    VMDFMT=1
+fi
+
+# Generate exit value
+if [ ! -z $VMDFMT ] || [ ! $LINKCHECK -eq 0 ] ; then
     exit 2
 fi

--- a/src/config/cron.md
+++ b/src/config/cron.md
@@ -9,5 +9,5 @@ Available choices include [cronie](https://github.com/cronie-crond/cronie/),
 
 As alternative to the standard cron implementations you can use something like
 [snooze](https://github.com/leahneukirchen/snooze) or
-[runwhen](http://code.dogmap.org/runwhen/) which go hand in hand with service
+[runwhen](https://code.dogmap.org/runwhen/) which go hand in hand with service
 supervision.

--- a/src/config/date-time.md
+++ b/src/config/date-time.md
@@ -45,7 +45,7 @@ NTP is the official reference implementation of the Network Time Protocol.
 
 The `ntp` package provides NTP and the `isc-ntpd` service.
 
-For further information, visit [the NTP site](http://www.ntp.org/).
+For further information, visit [the NTP site](https://www.ntp.org).
 
 ### OpenNTPD
 

--- a/src/config/texlive.md
+++ b/src/config/texlive.md
@@ -88,4 +88,4 @@ To update installed packages:
 
 For a full description, check:
 
-<http://www.tug.org/texlive/doc/tlmgr.html>
+<https://www.tug.org/texlive/doc/tlmgr.html>

--- a/src/contributing/void-docs/style-guide.md
+++ b/src/contributing/void-docs/style-guide.md
@@ -99,6 +99,23 @@ They should not be formatted like this:
 [https://www.example.com/](https://www.example.com/)
 ```
 
+### Checking links
+
+If you're including new links (either internal or external) in the docs or
+changing the current file structure, you should install `mdbook-linkcheck`,
+which can be obtained from the Void repos or by using `cargo`. You can then
+build the mdBook locally, which will run a linkcheck as well, or run it in
+standalone mode:
+
+```
+$ mdbook-linkcheck -s
+```
+
+This way, linkcheck will verify all the references, and warn you if there are
+any issues. If any link you're using is correct but generating errors for some
+reason, you can add its domain to the exclude list in `book.toml`, under the
+`[mdbook.linkcheck]` key.
+
 ## Case
 
 Filenames and directories should use [kebab

--- a/src/xbps/packages/building.md
+++ b/src/xbps/packages/building.md
@@ -3,4 +3,4 @@
 Building packages from source is an advanced topic that is best left to the
 documentation in the void-packages repository.
 
-This repository can be found at <http://github.com/void-linux/void-packages/>.
+This repository can be found at <https://github.com/void-linux/void-packages/>.


### PR DESCRIPTION
This addition wouldn't make anyone unable to build locally, because it only uses the plugin if it finds it in the path. For CI, it makes sense to error out.

I need help with setting up CI for it, though. The current one only runs `vmdfmt`, we'd need to run `mdbook build` as well.