### PR TITLE
linkcheck: fix links to mdBook

### DIFF
--- a/src/contributing/void-docs/style-guide.md
+++ b/src/contributing/void-docs/style-guide.md
@@ -3,7 +3,7 @@
 This style guide outlines the standards for contributing to the
 [void-docs](https://github.com/void-linux/void-docs/) project. The manual on
 <https://docs.voidlinux.org> is generated from an
-[mdBook](https://rust-lang-nursery.github.io/mdBook/) stored in the
+[mdBook](https://rust-lang.github.io/mdBook/) stored in the
 [void-docs](https://github.com/void-linux/void-docs/) repository.
 
 ## General

--- a/src/contributing/void-docs/submitting.md
+++ b/src/contributing/void-docs/submitting.md
@@ -14,9 +14,9 @@ To clone the repository and push changes
 `git` package.
 
 Building the Void Handbook locally requires
-[mdBook](https://rust-lang-nursery.github.io/mdBook/), which can be installed
-with the `mdBook` package on Void. At the root of the void-docs repository
-`mdbook serve` can be run to serve the docs on your localhost.
+[mdBook](https://rust-lang.github.io/mdBook/), which can be installed with the
+`mdBook` package on Void. At the root of the void-docs repository `mdbook serve`
+can be run to serve the docs on your localhost.
 
 ## Forking
 


### PR DESCRIPTION
The project moved from rust-lang-nursery to rust-lang.