### PR TITLE
connman: fix man links and formatting

### DIFF
--- a/src/config/network/connman.md
+++ b/src/config/network/connman.md
@@ -1,17 +1,15 @@
 # ConnMan
 
-[ConnMan(8)](https://man.voidlinux.org/connman.8/) is a daemon that manages
+[ConnMan(8)](https://man.voidlinux.org/connman.8) is a daemon that manages
 network connections, is designed to be slim and to use as few resources as
-possible. The `connman` package contains the basic utilities to run
-[ConnMan(8)](https://man.voidlinux.org/connman.8/).
+possible. The `connman` package contains the basic utilities to run ConnMan.
 
 ## Starting ConnMan
 
-To enable the [ConnMan(8)](https://man.voidlinux.org/connman.8/) daemon, first
-[disable](../services/index.md) any other network managing services like
-[dhcpcd](dhcpcd.md), [wpa_supplicant](wpa_supplicant.md), or `wicd`. These
-services all control network interface configuration, and interfere with each
-other.
+To enable the ConnMan daemon, first [disable](../services/index.md) any other
+network managing services like [dhcpcd](dhcpcd.md),
+[wpa_supplicant](wpa_supplicant.md), or `wicd`. These services all control
+network interface configuration, and interfere with each other.
 
 Finally, enable the `connmand` service.
 
@@ -19,14 +17,12 @@ Finally, enable the `connmand` service.
 
 The `connman` package includes a command line tool,
 [connmanctl(1)](https://man.voidlinux.org/connmanctl.1) to control network
-settings. If you do not provide any commands
-[connmanctl(1)](https://man.voidlinux.org/connmanctl.1) starts as an interactive
-shell.
+settings. If you do not provide any commands, `connmanctl` starts as an
+interactive shell.
 
-There are many other front-ends to
-[ConnMan(8)](https://man.voidlinux.org/connman.8/), including `connman-ui` for
-system trays, `connman-gtk` for GTK, `cmst` for QT and `connman-ncurses` for
-ncurses based UI.
+There are many other front-ends to ConnMan, including `connman-ui` for system
+trays, `connman-gtk` for GTK, `cmst` for QT and `connman-ncurses` for ncurses
+based UI.
 
 ## Preventing DNS overrides by ConnMan
 


### PR DESCRIPTION
- Forward slash in man links was causing bad request from server.

- Removed links to the man pages after the first one.