### PR TITLE
downloading: remove header about using GPG

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -5,9 +5,9 @@
    - [About this Handbook](./about-handbook/index.md)
    - [InfraDocs](./about/meta/infradocs.md)
 - [Installation](./installation/index.md)
+   - [Downloading Installation Media](./installation/downloading.md)
    - [Base System Requirements](./installation/base-requirements.md)
    - [Live Installers](./installation/live-images/index.md)
-      - [Downloading Images](./installation/live-images/downloading.md)
       - [Prepare Installation Media](./installation/live-images/prep.md)
       - [Partitioning Notes](./installation/live-images/partitions.md)
       - [Installation Guide](./installation/live-images/guide.md) =======

--- a/src/installation/downloading.md
+++ b/src/installation/downloading.md
@@ -1,10 +1,12 @@
-# Downloading Images
+# Downloading Installation Media
 
-The most recent live images can be downloaded from
-<https://alpha.de.repo.voidlinux.org/live/current/>. Previous releases can be
-found under <https://alpha.de.repo.voidlinux.org/live/>, organized by date.
+The most recent live images and rootfs tarballs can be downloaded from
+<https://alpha.de.repo.voidlinux.org/live/current/>. They can also be downloaded
+from [other mirrors](../xbps/repositories/mirrors/index.md). Previous releases
+can be found under <https://alpha.de.repo.voidlinux.org/live/>, organized by
+date.
 
-## Verify images
+## Verifying images
 
 Each image release's directory contains two files used to verify the image(s)
 you download. First, there is a `sha256.txt` file containing image checksums to
@@ -18,7 +20,7 @@ want to download both files:
 $ wget http://alpha.de.repo.voidlinux.org/live/current/sha256.{txt,sig}
 ```
 
-### Verify image integrity
+### Verifying image integrity
 
 You can verify the integrity of a downloaded file using
 [sha256sum(1)](https://man.voidlinux.org/sha256sum.1) with the `sha256.txt` file
@@ -32,16 +34,17 @@ void-live-x86_64-musl-20170220.iso: OK
 
 This verifies that the image is not corrupt.
 
-### Verify digital signature
+### Verifying digital signature
 
 Prior to using any image you're strongly encouraged to validate the signatures
 on the image to ensure they haven't been tampered with.
 
 Current images are signed using a signify key that is specific to the release.
-If you're on Void already, you can obtain the keys from the void-release-keys
+If you're on Void already, you can obtain the keys from the `void-release-keys`
 package, which will be downloaded using your existing XBPS trust relationship
-with your mirror. You will also need a copy of signify; on Void this is provided
-by the `outils` package.
+with your mirror. You will also need a copy of
+[signify(1)](https://man.voidlinux.org/signify.1); on Void this is provided by
+the `outils` package.
 
 If you are not currently using Void Linux you will need to obtain a copy of
 signify by other means, and the appropriate signing key from our git repository

--- a/src/installation/downloading.md
+++ b/src/installation/downloading.md
@@ -13,19 +13,15 @@ you download. First, there is a `sha256.txt` file containing image checksums to
 verify the integrity of the downloaded images. Second is the `sha256.sig` file,
 used to verify the authenticity of the checksums.
 
-We want to verify both the image's integrity and authenticity, so for this, we
-want to download both files:
-
-```
-$ wget http://alpha.de.repo.voidlinux.org/live/current/sha256.{txt,sig}
-```
+It is necessary to verify both the image's integrity and authenticity. It is,
+therefore, recommended that you download both files.
 
 ### Verifying image integrity
 
 You can verify the integrity of a downloaded file using
 [sha256sum(1)](https://man.voidlinux.org/sha256sum.1) with the `sha256.txt` file
-downloaded above. The following sha256sum command will check (`-c`) the
-integrity of only the image(s) you've downloaded:
+downloaded above. The following command will check the integrity of only the
+image(s) you have downloaded:
 
 ```
 $ sha256sum -c --ignore-missing sha256.txt
@@ -46,13 +42,23 @@ with your mirror. You will also need a copy of
 [signify(1)](https://man.voidlinux.org/signify.1); on Void this is provided by
 the `outils` package.
 
-If you are not currently using Void Linux you will need to obtain a copy of
-signify by other means, and the appropriate signing key from our git repository
+To obtain `signify` when using a Linux distribution or operating system other
+than Void Linux:
+
+- Install the `signify` package in Arch Linux and Arch-based distros.
+- Install the `signify-openbsd` package in Debian and Debian-based distros.
+- Install the package listed
+   [here](https://repology.org/project/signify-openbsd/versions) for your
+   distribution.
+- Install `signify-osx` with homebrew in macOS.
+
+If you are not currently using Void Linux, it will also be necessary to obtain
+the appropriate signing key from our Git repository
 [here](https://github.com/void-linux/void-packages/tree/master/srcpkgs/void-release-keys/files/).
 
-Once you've obtained the key, you can verify your image with the sha256.sig
-file. An example is shown here verifying the GCP musl filesystem from the
-20191109 release:
+Once you've obtained the key, you can verify your image with the `sha256.sig`
+file. The following example demonstrates the verification of the GCP musl
+filesystem from the 20191109 release:
 
 ```
 $ signify -C -p /etc/signify/void-release-20191109.pub -x sha256.sig void-GCP-musl-PLATFORMFS-20191109.tar.xz
@@ -60,6 +66,6 @@ Signature Verified
 void-GCP-musl-PLATFORMFS-20191109.tar.xz: OK
 ```
 
-If the verification process does not spit out the expected "OK" status then do
-not use it! Please alert the Void Linux team of where you got the image and how
-you verified it and we will follow up.
+If the verification process does not produce the expected "OK" status, do not
+use it! Please alert the Void Linux team of where you got the image and how you
+verified it, and we will follow up on it.

--- a/src/installation/downloading.md
+++ b/src/installation/downloading.md
@@ -52,6 +52,10 @@ than Void Linux:
    distribution.
 - Install `signify-osx` with homebrew in macOS.
 
+If you can't obtain `signify` for some reason (e.g. you are on Windows and can't
+use WSL or MinGW), you can use
+[minisign(1)](https://man.voidlinux.org/minisign.1) to verify the file.
+
 If you are not currently using Void Linux, it will also be necessary to obtain
 the appropriate signing key from our Git repository
 [here](https://github.com/void-linux/void-packages/tree/master/srcpkgs/void-release-keys/files/).
@@ -69,3 +73,16 @@ void-GCP-musl-PLATFORMFS-20191109.tar.xz: OK
 If the verification process does not produce the expected "OK" status, do not
 use it! Please alert the Void Linux team of where you got the image and how you
 verified it, and we will follow up on it.
+
+For verification with `minisign`, it is necessary to rename the `sha56.sig` file
+to `sha256.txt.minisig` and remove the first line from the `.pub` release key.
+The following example demonstrates the verification of the `sha256.txt` file
+from the 20191109 release:
+
+```
+$ minisign -Vm sha256.txt -f -p void-release-20191109.pub
+void-release-20191109.pub: Success
+```
+
+The same warning as above applies. If the verification process isn't successful,
+do not use the file - warn the Void Linux team about it.

--- a/src/installation/live-images/downloading.md
+++ b/src/installation/live-images/downloading.md
@@ -22,7 +22,7 @@ $ wget http://alpha.de.repo.voidlinux.org/live/current/sha256.{txt,sig}
 
 You can verify the integrity of a downloaded file using
 [sha256sum(1)](https://man.voidlinux.org/sha256sum.1) with the `sha256.txt` file
-we downloaded above. The following sha256sum command will check (`-c`) the
+downloaded above. The following sha256sum command will check (`-c`) the
 integrity of only the image(s) you've downloaded:
 
 ```
@@ -32,45 +32,31 @@ void-live-x86_64-musl-20170220.iso: OK
 
 This verifies that the image is not corrupt.
 
-### Verify image authenticity
+### Verify digital signature
 
-To verify that the downloaded `sha256.txt` file is the one that the Void Linux
-maintainers published and signed, we use PGP. For this, we need the `sha256.sig`
-downloaded above.
+Prior to using any image you're strongly encouraged to validate the signatures
+on the image to ensure they haven't been tampered with.
 
-The file is signed with the Void Images key:
+Current images are signed using a signify key that is specific to the release.
+If you're on Void already, you can obtain the keys from the void-release-keys
+package, which will be downloaded using your existing XBPS trust relationship
+with your mirror. You will also need a copy of signify; on Void this is provided
+by the `outils` package.
 
-- **Signer:** Void Linux Image Signing Key
-   <[images@voidlinux.eu](mailto:images@voidlinux.eu)>
-- **KeyID:** `B48282A4`
-- **Fingerprint:** `CF24 B9C0 3809 7D8A 4495 8E2C 8DEB DA68 B482 82A4`
+If you are not currently using Void Linux you will need to obtain a copy of
+signify by other means, and the appropriate signing key from our git repository
+[here](https://github.com/void-linux/void-packages/tree/master/srcpkgs/void-release-keys/files/).
 
-You can use [gpg(1)](https://man.voidlinux.org/gpg.1) to receive the key from a
-keyserver using the command in the following example. You can also download it
-from <https://alpha.de.repo.voidlinux.org/live/current/void_images.asc>.
-
-```
-$ gpg --recv-keys B48282A4
-gpg: requesting key B48282A4 from hkp server keys.gnupg.net
-gpg: key B48282A4: public key "Void Linux Image Signing Key <images@voidlinux.eu>" imported
-gpg: no ultimately trusted keys found
-gpg: Total number processed: 1
-gpg:               imported: 1  (RSA: 1)
-```
-
-With the key stored locally, you can use
-[gpg(1)](https://man.voidlinux.org/gpg.1) verify the signature of `sha256.txt`
-using the `sha256.sig` file:
+Once you've obtained the key, you can verify your image with the sha256.sig
+file. An example is shown here verifying the GCP musl filesystem from the
+20191109 release:
 
 ```
-$ gpg --verify sha256.sig
-gpg: assuming signed data in `sha256.txt'
-gpg: Signature made Sat Oct  7 17:18:35 2017 CDT using RSA key ID B48282A4
-gpg: Good signature from "Void Linux Image Signing Key <images@voidlinux.eu>"
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: CF24 B9C0 3809 7D8A 4495  8E2C 8DEB DA68 B482 82A4
+$ signify -C -p /etc/signify/void-release-20191109.pub -x sha256.sig void-GCP-musl-PLATFORMFS-20191109.tar.xz
+Signature Verified
+void-GCP-musl-PLATFORMFS-20191109.tar.xz: OK
 ```
 
-This verifies that the signature for the checksums is authentic. In turn, we can
-assert that the downloaded images are also authentic if their checksums match.
+If the verification process does not spit out the expected "OK" status then do
+not use it! Please alert the Void Linux team of where you got the image and how
+you verified it and we will follow up.

--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-Once you have [downloaded](./downloading.md) a Void image to install and
+Once you have [downloaded](../downloading.md) a Void image to install and
 [prepared](./prep.md) your install media, you are ready to install Void Linux.
 
 > Note: before you begin installation, you should determine whether your machine

--- a/src/installation/live-images/prep.md
+++ b/src/installation/live-images/prep.md
@@ -1,6 +1,6 @@
 # Prepare Installation Media
 
-After [downloading a live image](./downloading.md), it must be written to
+After [downloading a live image](../downloading.md), it must be written to
 bootable media, such as a USB drive, SD card, or CD/DVD.
 
 ## Create a bootable USB drive or SD card on Linux


### PR DESCRIPTION
The current verification is done through signify, and the GPG key is expired.

Fixes #232