### PR TITLE
kde: Add section.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -49,6 +49,7 @@
       - [Xorg](./config/graphical-session/xorg.md)
       - [Wayland](./config/graphical-session/wayland.md)
       - [GNOME](./config/graphical-session/gnome.md)
+      - [KDE](./config/graphical-session/kde.md)
    - [Multimedia](./config/media/index.md)
       - [ALSA](./config/media/alsa.md)
       - [PulseAudio](./config/media/pulseaudio.md)

--- a/src/config/graphical-session/kde.md
+++ b/src/config/graphical-session/kde.md
@@ -1,0 +1,19 @@
+# KDE
+
+## Installation
+
+Install the `kde5` package, and optionally, the `kde5-baseapps` package.
+
+To use the "Networks" widget, enable the `dbus` and `NetworkManager` services.
+
+Installing the `kde5` package also installs the `sddm` package, which provides
+the `sddm` service for the Simple Desktop Display Manager; [test the
+service](../services/managing.html#testing-services) before enabling it. If you
+are not intending to run SDDM via a remote X server, you will need to install
+either the `xorg-minimal` package or the `xorg` package. By default, SDDM will
+start an Xorg-based Plasma session, but you can request a Wayland-based Plasma
+session instead.
+
+If you wish to start an Xorg-based session from the console, use
+[startx](./xorg.html#startx) to run `startplasma-x11`. For a Wayland-based
+session, run `startplasma-wayland` directly.


### PR DESCRIPTION
This PR is based on the 'KDE' page of the old wiki.

The `kde5` package pulls in the `elogind`, `NetworkManager`, `sddm`, `udisks2` and `upower` packages, so there's no need for the user to install them manually.

The `dbus` service does not need to be enabled for a Plasma session to be started via `startx`. However, one does need to enable *both* the `dbus` and `NetworkManager` services (rather than e.g. `NetworkManager` alone) in order to use the "Networks" widget.

Since `elogind` is available, there's no need to include a 'troubleshooting' question with the answer "Install `elogind`". i presume the presence of `elogind` also means there should be no need for users to be added to the `storage` group?

i've also not included the "No shutdown, reboot buttons ..." entry, as i didn't observe this behaviour in testing.

For some reason, trying to do `sv once sddm` didn't work, but resulted in the message

    fail: sddm: unable to change to service directory: file does not exist
    
Does anyone have any suggestions as to what the problem might be here? i'd certainly like the page to suggest that users test out SDDM that way before enabling it.

The addition of this section would mean we could create a 'Desktop Environments' section in the Handbook, but i'd prefer to not do anything on that front until this PR is merged. One step at a time. :-)