### PR TITLE
README: use local link instead of full GH one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 Welcome to the Void documentation. This repository contains the source data
 behind <https://docs.voidlinux.org/>. Contributing to this repository follows
-the same protocol as the packages tree. For details, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md).
+the same protocol as the packages tree. For details, please read
+[CONTRIBUTING](./CONTRIBUTING.md).


### PR DESCRIPTION
This makes it possible to inspect different branches of void-docs using
the links. It's also shorter.