### PR TITLE
alsa: Link to `apulse` project README for now.

### DIFF
--- a/src/config/media/alsa.md
+++ b/src/config/media/alsa.md
@@ -9,7 +9,9 @@ respectively.
 
 To allow use of software requiring PulseAudio, install the `apulse` package.
 `apulse` provides part of the PulseAudio interface expected by applications,
-translating calls to that interface into calls to ALSA.
+translating calls to that interface into calls to ALSA. For details about using
+`apulse`, consult [the project
+README](https://github.com/i-rinat/apulse/blob/master/README.md).
 
 ## Configuration
 


### PR DESCRIPTION
If and when i-rinat/apulse/pull/112 gets merged, we can then link to `apulse.1` on `man.voidlinux.org` instead.
