### PR TITLE
book.toml: add ntp.org to exclude list

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,4 +9,4 @@ theme = "src/theme"
 
 [output.linkcheck]
 follow-web-links = true
-exclude = [ "kernel.org", "\\.onion", "localhost", "hushan.tech" ]
+exclude = [ "kernel.org", "ntp.org", "\\.onion", "localhost", "hushan.tech" ]

--- a/src/config/date-time.md
+++ b/src/config/date-time.md
@@ -45,7 +45,7 @@ NTP is the official reference implementation of the Network Time Protocol.
 
 The `ntp` package provides NTP and the `isc-ntpd` service.
 
-For further information, visit [the NTP site](https://www.ntp.org).
+For further information, visit [the NTP site](https://www.ntp.org/).
 
 ### OpenNTPD
 


### PR DESCRIPTION
It was causing timeouts in CI, and sometimes locally as well.
Not very reliable.

@flexibeast looks good? I say we wait for CI.