### PR TITLE
book.toml: remove linkcheck plugin

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,7 +6,3 @@ title = "Void Linux Handbook"
 
 [output.html]
 theme = "src/theme"
-
-[output.linkcheck]
-follow-web-links = true
-exclude = [ "kernel.org", "ntp.org", "\\.onion", "localhost", "hushan.tech" ]


### PR DESCRIPTION
Could be a temporary removal, adding new backends causes the creation of new folders