### PR TITLE
Revert "book.toml: remove linkcheck plugin"

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,7 @@ title = "Void Linux Handbook"
 
 [output.html]
 theme = "src/theme"
+
+[output.linkcheck]
+follow-web-links = true
+exclude = [ "kernel.org", "ntp.org", "\\.onion", "localhost", "hushan.tech" ]

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -2,7 +2,8 @@
 
 echo "Installing mdbook-linkcheck"
 
-curl -sL -o ~/bin/linkcheck.tar.gz https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.5.1/mdbook-linkcheck-v0.5.1-x86_64-unknown-linux-gnu.tar.gz
+_version="v0.6.0"
+curl -sL -o ~/bin/linkcheck.tar.gz "https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/${_version}/mdbook-linkcheck-${_version}-x86_64-unknown-linux-gnu.tar.gz"
 
 tar xvf ~/bin/linkcheck.tar.gz -C ~/bin
 


### PR DESCRIPTION
This reverts commit f0d5ba08932aadbf893a7762b69ab9d7419aaa49.

Fixing the deployment script makes it possible to have multiple backends
again.

Waiting for https://github.com/void-ansible-roles/mdbook/pull/1