### PR TITLE
gnome: Modify dependencies needed for minimal installation.

### DIFF
--- a/src/config/graphical-session/gnome.md
+++ b/src/config/graphical-session/gnome.md
@@ -10,13 +10,13 @@ the changes to take effect.
 Install the `gnome` package for a GNOME environment which includes GNOME
 applications.
 
-A minimal GNOME environment can be created by installing the `gnome-session`,
-`gdm` and `adwaita-icon-theme` packages. (Note, however, that not all GNOME
-features may be present or functional.) `gdm` defaults to providing a Wayland
-session, via the `mutter` window manager. For an Xorg session, install the
-`xorg` package, then select 'GNOME on Xorg' at the GDM login screen, or start
-`gnome-session` via `~/.xinitrc`. GNOME applications can be installed via the
-`gnome-apps` package.
+A minimal GNOME environment can be created by installing the `mesa-dri`,
+`gnome-session`, `gdm` and `adwaita-icon-theme` packages. (Note, however, that
+not all GNOME features may be present or functional.) `gdm` defaults to
+providing a Wayland session, via the `mutter` window manager. For an Xorg
+session, select 'GNOME on Xorg' at the GDM login screen, or use `startx` by
+installing the `xinit` package and adding `gnome-session` to your `~/.xinitrc`.
+GNOME applications can be installed via the `gnome-apps` package.
 
 If you require [ZeroConf](http://www.zeroconf.org/) support, install the `avahi`
 package and enable the `avahi-daemon` service.


### PR DESCRIPTION
Testing in a VM found that both `gdm` and `gnome-session` require `mesa-dri` to be installed for either to start up properly. Additionally, the `xinit` package needs to be installed in order to be able to make use of `startx`.
