### PR TITLE
src/theme/index.hbs: skip to content link skips table of contents

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -31,7 +31,7 @@
 		<header>
 			<nav id="void-nav">
 				<ul>
-					<li><a id="skip-to-content" tabindex="1" href="#content">Skip to content</a></li>
+					<li><a id="skip-to-content" tabindex="1" href="#main">Skip to content</a></li>
 					<li>
 						<button id="sidebar-toggle" class="icon-button" type="button" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -103,7 +103,7 @@
 				</div>
 				{{/if}}
 
-				<main>
+				<main id="main">
 					{{{ content }}}
 				</main>
 


### PR DESCRIPTION
The skip to content link currently points to the beginning of the table of contents. it should point to the beginning of the article.
