### PR TITLE
xbps/trouble/common-errors: fix links

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -81,6 +81,7 @@
       - [Custom Repositories](./xbps/repositories/custom.md)
       - [Signing Repositories](./xbps/repositories/signing.md)
    - [Troubleshooting](./xbps/troubleshooting/index.md)
+      - [Common Errors](./xbps/troubleshooting/common-errors.md)
       - [Static XBPS](./xbps/troubleshooting/static.md)
 - [Contributing](./contributing/index.md)
    - [Usage Statistics](./contributing/usage-statistics.md)

--- a/src/xbps/troubleshooting/common-errors.md
+++ b/src/xbps/troubleshooting/common-errors.md
@@ -1,4 +1,4 @@
-# Common errors
+# Common Errors
 
 ## Errors while updating or installing packages
 

--- a/src/xbps/troubleshooting/index.md
+++ b/src/xbps/troubleshooting/index.md
@@ -6,5 +6,5 @@ working with XBPS.
 
 ## Section Contents
 
+- [Common Errors](./common-errors.md)
 - [Static XBPS](./static.md)
-- [Common errors](./common-errors.md)


### PR DESCRIPTION
mdBook doesn't check links in an adequate manner.
