### PR TITLE
src/theme/css/default.css: fix design for 700-890px

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -305,7 +305,7 @@ body {
 }
 
 /* whatever, just hide the nav */
-@media only screen and (max-width: 700px) {
+@media only screen and (max-width: 890px) {
 	#void-nav ul.right {
 		display: none;
 	}


### PR DESCRIPTION
Before this commit, if you resized your window to be 700-890px wide, you would get all the text in a narrow column on the left. This fixes it, but I am not sure if I fixed the root of the problem or if this is only a workaround.