### PR TITLE
theme/css/general.css: use dark theme if prefered

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -325,11 +325,11 @@ body {
 	}
 
 	code {
-		background: #264434;
+		background: inherit;
 	}
 	pre {
-		background: #264434;
-		border: 1px solid #192d22;
+		background: #514749;
+		border: 1px solid #222;
 	}
 
 	blockquote {
@@ -337,13 +337,13 @@ body {
 		border: 1px solid #222;
 	}
 	table td {
-		border: 1px #353535 solid;
+		border: 1px #3c3c3c solid;
 	}
 	table thead {
-		background: #353535;
+		background: #3c3c3c;
 	}
 	table tbody tr:nth-child(2n) {
-		background: #353535;
+		background: #3c3c3c;
 	}
 
 	/* nav */

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -310,3 +310,74 @@ body {
 		display: none;
 	}
 }
+
+@media (prefers-color-scheme: dark) {
+	body {
+		color: #ccc;
+		background-color: #333;
+	}
+	h1, h2, h3, h4, h5, h6 { color: #ccc; }
+	a {
+		color: #62b086;
+	}
+	a:hover {
+		color: #ccc;
+	}
+
+	code {
+		background: #264434;
+	}
+	pre {
+		background: #264434;
+		border: 1px solid #192d22;
+	}
+
+	blockquote {
+		background: #514749;
+		border: 1px solid #222;
+	}
+	table td {
+		border: 1px #353535 solid;
+	}
+	table thead {
+		background: #353535;
+	}
+	table tbody tr:nth-child(2n) {
+		background: #353535;
+	}
+
+	/* nav */
+	#void-nav ul li a:hover,
+	#void-nav ul li a:focus,
+	#void-nav button:hover,
+	#void-nav button:focus,
+	#void-nav label:hover,
+	#void-nav label:focus {
+		background: #333;
+	}
+
+	/* sidebar  */
+	#sidebar {
+		background: #353535;
+	}
+	#sidebar a {
+		color: #ccc;
+	}
+	#sidebar a:hover {
+		color: #62b086;
+	}
+	#sidebar a.active {
+		color: #62b086;
+	}
+
+	/* search */
+	#searchbar {
+		background-color: #333;
+		color: #ccc;
+	}
+
+	/* chapter navigation */
+	.nav-chapters:hover {
+		fill: #fff
+	}
+}

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -314,7 +314,7 @@ body {
 @media (prefers-color-scheme: dark) {
 	body {
 		color: #ccc;
-		background-color: #333;
+		background-color: #222;
 	}
 	h1, h2, h3, h4, h5, h6 { color: #ccc; }
 	a {
@@ -328,22 +328,33 @@ body {
 		background: inherit;
 	}
 	pre {
-		background: #514749;
-		border: 1px solid #222;
+		background: #353535;
+		border: 1px solid #111;
 	}
 
 	blockquote {
-		background: #514749;
-		border: 1px solid #222;
+		background: inherit;
+		border-left: .2em solid #ccc;
+		border-right: none;
+		border-top: none;
+		border-bottom: none;
+		padding-top: .5em;
+		padding-bottom: .5em;
+		padding-left: 1em;
+		padding-right: 1em;
+		margin-left: 1em;
+	}
+	blockquote code {
+		color: #62b086;
 	}
 	table td {
-		border: 1px #3c3c3c solid;
+		border: 1px #2c2c2c solid;
 	}
 	table thead {
-		background: #3c3c3c;
+		background: #2c2c2c;
 	}
 	table tbody tr:nth-child(2n) {
-		background: #3c3c3c;
+		background: #2c2c2c;
 	}
 
 	/* nav */
@@ -353,12 +364,16 @@ body {
 	#void-nav button:focus,
 	#void-nav label:hover,
 	#void-nav label:focus {
-		background: #333;
+		background: #222;
+	}
+
+	#void-nav {
+		background: #295340;
 	}
 
 	/* sidebar  */
 	#sidebar {
-		background: #353535;
+		background: #252525;
 	}
 	#sidebar a {
 		color: #ccc;
@@ -372,7 +387,7 @@ body {
 
 	/* search */
 	#searchbar {
-		background-color: #333;
+		background-color: #222;
 		color: #ccc;
 	}
 


### PR DESCRIPTION
This PR uses the new prefers-color-scheme media query to determine if user's OS is set to dark mode (or browser is manually set to dark mode) and uses dark theme.

Let me know if I should improve something.

![](https://ttm.sh/QQw.png)