### PR TITLE
Remove block quotes from all documents, except actual quotes

### DIFF
--- a/src/config/bluetooth.md
+++ b/src/config/bluetooth.md
@@ -21,9 +21,9 @@ Then, add your user to the `bluetooth` group and restart the `dbus` service, or
 simply reboot the system. Note that restarting the `dbus` service may kill
 processes making use of it.
 
-> Note: To use an audio device such as a wireless speaker or headset, ALSA users
-> need to install the `bluez-alsa` package, while
-> [PulseAudio](./media/pulseaudio.md) users do not need any additional software.
+To use an audio device such as a wireless speaker or headset, ALSA users need to
+install the `bluez-alsa` package, while [PulseAudio](./media/pulseaudio.md)
+users do not need any additional software.
 
 ## Usage
 

--- a/src/config/external-applications.md
+++ b/src/config/external-applications.md
@@ -47,8 +47,8 @@ Flatpak is another method for installing external proprietary applications on
 Linux. For information on using Flatpak with Void Linux, see the [official
 Flatpak documentation](https://flatpak.org/setup/Void%20Linux/).
 
-> Flatpak's sandboxing will not necessarily protect you from any security and/or
-> privacy-violating features of proprietary software.
+**Warning:** Flatpak's sandboxing will not necessarily protect you from any
+security and/or privacy-violating features of proprietary software.
 
 ### Troubleshooting
 

--- a/src/config/graphical-session/graphics-drivers/intel.md
+++ b/src/config/graphical-session/graphics-drivers/intel.md
@@ -9,8 +9,8 @@ dependency. If you installed a version-specific kernel package (e.g.,
 
 Install the Mesa DRI package, `mesa-dri`.
 
-> Note: This is already included in the `xorg` meta-package, but it is needed
-> when installing xorg via `xorg-minimal` or for running a Wayland compositor.
+Note: This is already included in the `xorg` meta-package, but it is needed when
+installing Xorg via `xorg-minimal` or for running a Wayland compositor.
 
 ## Vulkan
 

--- a/src/config/graphical-session/graphics-drivers/optimus.md
+++ b/src/config/graphical-session/graphics-drivers/optimus.md
@@ -51,7 +51,7 @@ Offloading Graphics Display with RandR 1.4
 - allows to switch to the NVIDIA GPU on a per-application basis
 - `nouveau` is a reverse-engineered driver and offers poor performance
 
-> Note: different methods are mutually exclusive.
+The above methods are mutually exclusive.
 
 ## PRIME Render Offload
 
@@ -84,7 +84,7 @@ For more information, see NVIDIA's
 
 Enable the `bumblebeed` service and add the user to the `bumblebee` group.
 
-> Note: This requires a re-login to be effective.
+Note: This requires a re-login to be effective.
 
 Run the application to be rendered on the NVIDIA GPU with `optirun`:
 
@@ -100,9 +100,8 @@ $ optirun glxinfo | grep "renderer string"
 
 ## Nouveau PRIME
 
-> Note: This method uses the open source `nouveau` driver, which is blacklisted
-> by NVIDIA drivers. Uninstall any NVIDIA driver present on your system and
-> reboot.
+Note: This method uses the open source `nouveau` driver, which is blacklisted by
+NVIDIA drivers. Uninstall any NVIDIA driver present on your system and reboot.
 
 Set `DRI_PRIME=1` to run an application on the NVIDIA GPU:
 

--- a/src/config/network/iwd.md
+++ b/src/config/network/iwd.md
@@ -7,9 +7,9 @@ for Linux that aims to replace [WPA supplicant](./wpa_supplicant.md).
 
 Install the `iwd` package and enable the `dbus` and `iwd` services.
 
-> Note: To use EAP-TLS, EAP-TTLS, and EAP-PEAP based configurations, version
-> ≥4.20 of the kernel is required. Previous kernel versions do not include the
-> necessary cryptographic authentication modules.
+Note: To use EAP-TLS, EAP-TTLS, and EAP-PEAP based configurations, version
+≥4.20 of the kernel is required. Previous kernel versions do not include the
+necessary cryptographic authentication modules.
 
 ## Usage
 
@@ -19,8 +19,8 @@ as arguments; when run without arguments, it provides an interactive session. To
 list available commands, run either `iwctl help` or enter `help` at the
 interactive prompt.
 
-> Note: By default, only the root user and those in the `wheel` group have
-> permission to operate `iwctl`.
+Note: By default, only the root user and those in the `wheel` group have
+permission to operate `iwctl`.
 
 ## Configuration
 

--- a/src/config/security/hashboot.md
+++ b/src/config/security/hashboot.md
@@ -24,8 +24,8 @@ After installation it is important to run
 
 to create the configuration file and generate the index of the chosen options.
 
-> If this is not run after installation, next boot will stop with an emergency
-> shell.
+If this is not run after installation, the next boot will stop with an emergency
+shell.
 
 Possible options as KEY=VALUE in `/etc/hashboot.cfg`:
 

--- a/src/config/users-and-groups.md
+++ b/src/config/users-and-groups.md
@@ -16,9 +16,9 @@ belongs to.
 
 ## sudo
 
-> Note: [sudo(8)](https://man.voidlinux.org/sudo.8) is installed by default but
-> may not be configured. It is only necessary to configure sudo if you wish to
-> use it.
+Note: [sudo(8)](https://man.voidlinux.org/sudo.8) is installed by default but
+may not be configured. It is only necessary to configure sudo if you wish to use
+it.
 
 Use [visudo(8)](https://man.voidlinux.org/visudo.8) as root to edit the
 [sudoers(5)](https://man.voidlinux.org/sudoers.5) file.

--- a/src/installation/base-requirements.md
+++ b/src/installation/base-requirements.md
@@ -9,8 +9,8 @@ following minimums for most installations:
 | x86_64-musl  | x86_64           | 96MB | 600MB   |
 | i686-glibc   | Pentium 4 (SSE2) | 96MB | 700MB   |
 
-> Note: Flavor installations require more resources. How much more depends on
-> the flavor.
+Note: Flavor installations require more resources. How much more depends on the
+flavor.
 
 Void is not available for i386, i486, or i586 architectures.
 

--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -3,9 +3,9 @@
 Once you have [downloaded](../downloading.md) a Void image to install and
 [prepared](./prep.md) your install media, you are ready to install Void Linux.
 
-> Note: before you begin installation, you should determine whether your machine
-> boots using BIOS or UEFI. This will affect how you plan partitions. See
-> [Partitioning Notes](./partitions.md) for more detail.
+Note: before you begin installation, you should determine whether your machine
+boots using BIOS or UEFI. This will affect how you plan partitions. See
+[Partitioning Notes](./partitions.md) for more detail.
 
 ## Booting
 
@@ -42,8 +42,8 @@ To install packages provided on the install image, select `Local`. Otherwise,
 you may select `Network` to download the latest packages from the Void
 repository.
 
-> Note: if you are installing a desktop environment from a ''flavor'' image, you
-> MUST choose `Local` for the source!
+**Warning:** if you are installing a desktop environment from a "flavor" image,
+you must choose `Local` for the source!
 
 ## Hostname
 
@@ -86,12 +86,12 @@ list of disks. Select the disk you want to partition and the installer will
 launch `cfdisk` for that disk. Remember you must write the partition table to
 the drive before you exit the partition editor.
 
-> UEFI users are recommended to select GPT for the partition table and create a
-> partition (typically between 200MB-1GB) of type `EFI System` which will be
-> mounted at `/boot/efi`.
-> 
-> BIOS users are recommended to choose MBR. Advanced users may use GPT but will
-> need to create a special BIOS partition for `grub` to boot.
+UEFI users are recommended to select GPT for the partition table and create a
+partition (typically between 200MB-1GB) of type `EFI System` which will be
+mounted at `/boot/efi`.
+
+BIOS users are recommended to choose MBR. Advanced users may use GPT but will
+need to create a special BIOS partition for `grub` to boot.
 
 See the [Partitioning Notes](./partitions.md) for more details about
 partitioning your disk.
@@ -103,8 +103,7 @@ you will be prompted to choose a filesystem type, whether you want to create a
 new filesystem on the partition, and a mount point, if applicable. When you are
 finished, select `Done` to return to the main menu.
 
-> UEFI users will need to create a `vfat` filesystem, and mount it at
-> `/boot/efi`.
+UEFI users will need to create a `vfat` filesystem, and mount it at `/boot/efi`.
 
 ## Review settings
 

--- a/src/installation/live-images/prep.md
+++ b/src/installation/live-images/prep.md
@@ -39,8 +39,8 @@ umount: /dev/sdX: not mounted.
 The [dd(1)](https://man.voidlinux.org/man1/dd.1) command can be used to copy a
 live image to a storage device. Using dd, write the live image to the device:
 
-> **Warning**: this will destroy any data currently on the referenced device.
-> Exercise caution.
+**Warning**: this will destroy any data currently on the referenced device.
+Exercise caution.
 
 ```
 # dd bs=4M if=/path/to/void-live-ARCH-DATE-VARIANT.iso of=/dev/sdX
@@ -71,5 +71,5 @@ CD or DVD. The following free software applications are available
 - [K3B](https://userbase.kde.org/K3b)
 - [Xfburn](https://goodies.xfce.org/projects/applications/xfburn)
 
-> Note: with a CD or DVD, live sessions will be less responsive than with a USB
-> or hard drive.
+Note: with a CD or DVD, live sessions will be less responsive than with a USB or
+hard drive.

--- a/src/xbps/repositories/custom.md
+++ b/src/xbps/repositories/custom.md
@@ -22,9 +22,9 @@ For example, to define a remote repository:
 # echo 'repository=http://my.domain.com/repo' > /etc/xbps.d/my-remote-repo.conf
 ```
 
-> Note: Remote repositories need to be [signed](./signing.md).
-> [xbps-install(1)](https://man.voidlinux.org/xbps-install.1) refuses to install
-> packages from remote repositories if they are not signed.
+Remote repositories need to be [signed](./signing.md).
+[xbps-install(1)](https://man.voidlinux.org/xbps-install.1) refuses to install
+packages from remote repositories if they are not signed.
 
 Or, to define a local repository:
 

--- a/src/xbps/repositories/signing.md
+++ b/src/xbps/repositories/signing.md
@@ -33,4 +33,4 @@ Afterwards sign one or more packages with the following command:
 $ xbps-rindex --privkey private.pem --sign-pkg /path/to/repository/dir/*.xbps
 ```
 
-> Note: Future packages will not be automatically signed.
+Future packages will not be automatically signed.

--- a/src/xbps/updating.md
+++ b/src/xbps/updating.md
@@ -7,9 +7,9 @@ Like any other system, it is important to keep Void up-to-date. Use
 # xbps-install -Su
 ```
 
-XBPS must use a separate transaction to update itself. If your update includes
-the `xbps` package, you will need to run the above command a second time to
-apply the rest of the updates.
+XBPS must use a separate transaction to update itself. If your first update
+includes the package `xbps`, you will need to run an additional update for the
+rest of the system.
 
 ## Restarting Services
 


### PR DESCRIPTION
Reflects recent changes to the style guide, this PR removes every blockquote that was being used as an aside. Every remaining blockquote is a legitimate use of the tag. #290 

```
$ grep -R '^> ' src/
src/contributing/void-docs/submitting.md:> The commit message should be in the form of `section: what was changed`
src/contributing/void-docs/style-guide.md:> For example:
src/contributing/void-docs/style-guide.md:> 
src/contributing/void-docs/style-guide.md:> `$ ls -l`
src/contributing/void-docs/style-guide.md:> Now we need to install the CUPS drivers and configure them.
src/contributing/void-docs/style-guide.md:> Install and configure the CUPS drivers, then configure them as shown.
src/contributing/void-docs/style-guide.md:> You can also use program X for this purpose.
```

I have not made any decisions regarding "should only be used sparingly, and for non-critical information". Since this commit is essentially a list of every "Note" currently in the docs, this might be a good place to make decisions about what should be labeled a note and what shouldn't.