### PR TITLE
Fix size issues when navbar grows

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -84,17 +84,17 @@ svg {
 	padding: 1em;
 }
 
-.right {
-	float: right;
-}
-
 /* void navigation */
 
 #void-nav {
 	width: 100%;
-	height: 50px;
+	min-height: 50px;
 	background: #478061;
 	font-size: 14px;
+
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
 }
 #void-nav button,
 #void-nav label {
@@ -110,8 +110,13 @@ svg {
 	margin: 0;
 	padding: 0;
 }
+
+#void-nav ul#nav-right {
+	margin-left: auto;
+}
+
 #void-nav ul li {
-	float: left;
+	display: inline-block;
 }
 #void-nav ul li a {
 	color: #fff;
@@ -251,6 +256,7 @@ body {
 #content {
 	display: flex;
 	flex-direction: row;
+	width: 100%;
 }
 #page-wrapper {
 	width: 100%;
@@ -301,13 +307,6 @@ body {
 		align-content: center;
 		display: flex;
 		flex-direction: column;
-	}
-}
-
-/* whatever, just hide the nav */
-@media only screen and (max-width: 700px) {
-	#void-nav ul.right {
-		display: none;
 	}
 }
 

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -49,7 +49,7 @@
 					</li>
 				{{/if}}
 				</ul>
-				<ul class="right">
+				<ul id="nav-right">
 					<li><a href="https://www.voidlinux.org">Home</a></li>
 					<li><a href="https://www.voidlinux.org/news/">News</a></li>
 					<li><a href="https://www.voidlinux.org/download/">Download</a></li>


### PR DESCRIPTION
There's 2 aspects to these changes:

1. Making the docs work OK on a size that currently doesn't.  There's
some kind of overflow with the navbar, which causes the width to get
very small.
2. Making the navbar fully responsive with the left/right side.

The navbar will now automatically wrap as the screen can no longer
accommodate the right hand side.


*Before submitting a pull request, please read all the sections of the Handbook listed in [CONTRIBUTING](./CONTRIBUTING.md).*

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.