### PR TITLE
Update all links to reflect style guide changes.

### DIFF
--- a/src/config/network/connman.md
+++ b/src/config/network/connman.md
@@ -7,8 +7,8 @@ possible. The `connman` package contains the basic utilities to run ConnMan.
 ## Starting ConnMan
 
 To enable the ConnMan daemon, first [disable](../services/index.md) any other
-network managing services like [dhcpcd](dhcpcd.md),
-[wpa_supplicant](wpa_supplicant.md), or `wicd`. These services all control
+network managing services like [dhcpcd](./dhcpcd.md),
+[wpa_supplicant](./wpa_supplicant.md), or `wicd`. These services all control
 network interface configuration, and interfere with each other.
 
 Finally, enable the `connmand` service.

--- a/src/config/network/interface-names.md
+++ b/src/config/network/interface-names.md
@@ -4,4 +4,4 @@ In newer versions udev changed the well known traditional Linux naming scheme
 (`eth0`, `eth0`, `wlan0`, ...).
 
 This behavior can be reverted by adding `net.ifnames=0` to the [kernel
-cmdline](/config/kernel.html#cmdline).
+cmdline](../kernel.md#cmdline).

--- a/src/config/network/networkmanager.md
+++ b/src/config/network/networkmanager.md
@@ -10,7 +10,7 @@ package contains the basic utilities to run
 
 To enable the [NetworkManager(8)](https://man.voidlinux.org/NetworkManager.8)
 daemon, first [disable](../services/index.md) any other network managing
-services like [dhcpcd](dhcpcd.md), [wpa_supplicant](wpa_supplicant.md), or
+services like [dhcpcd](./dhcpcd.md), [wpa_supplicant](./wpa_supplicant.md), or
 `wicd`. These services all control network interface configuration, and
 interfere with each other.
 

--- a/src/contributing/void-docs/index.md
+++ b/src/contributing/void-docs/index.md
@@ -3,5 +3,5 @@
 The sources for this handbook are hosted in the
 [void-docs](https://github.com/void-linux/void-docs) repository on
 [GitHub](https://github.com). If you would like to make a contribution Please
-follow our [style guide](./style-guide.md) and [submit](submitting.md) a
+follow our [style guide](./style-guide.md) and [submit](./submitting.md) a
 pull-request.

--- a/src/installation/guides/index.md
+++ b/src/installation/guides/index.md
@@ -3,4 +3,4 @@
 Got weird hardware or an unusual setup? This is the section for guides about how
 to install Void on things that it doesn't usually like.
 
-[Installing Void with Full Disk Encryption](fde.md)
+[Installing Void with Full Disk Encryption](./fde.md)

--- a/src/xbps/repositories/custom.md
+++ b/src/xbps/repositories/custom.md
@@ -22,7 +22,7 @@ For example, to define a remote repository:
 # echo 'repository=http://my.domain.com/repo' > /etc/xbps.d/my-remote-repo.conf
 ```
 
-> Note: Remote repositories need to be [signed](signing.md).
+> Note: Remote repositories need to be [signed](./signing.md).
 > [xbps-install(1)](https://man.voidlinux.org/xbps-install.1) refuses to install
 > packages from remote repositories if they are not signed.
 

--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -2,7 +2,7 @@
 
 Void Linux maintains mirrors in several geographic regions for you to use. A
 fresh install will default to using the master mirror in Europe, but you may
-also [select a different mirror](changing.md) manually.
+also [select a different mirror](./changing.md) manually.
 
 ## Tier 1 mirrors
 
@@ -38,5 +38,5 @@ sub-repository.
 
 ## Tor Mirrors
 
-Void Linux is also mirrored on the Tor network. See [Using Tor Mirrors](tor.md)
-for more information.
+Void Linux is also mirrored on the Tor network. See [Using Tor
+Mirrors](./tor.md) for more information.


### PR DESCRIPTION
Every link starts with http , ./ , ../ or `#`: 

```
$ grep -RPo '\]\((?!http|..?/|#).*?\)' src/
src/contributing/void-docs/style-guide.md:](example.md#heading-text)
```

No internal link (viz links that start with a dot) contains `html`:

```
$ grep -RPo '\]\((?=html)\..*\)' src/
[no output]
```