### PR TITLE
about-handbook/index, style-guide: Add text about placeholders.

### DIFF
--- a/src/about-handbook/index.md
+++ b/src/about-handbook/index.md
@@ -24,3 +24,15 @@ Examples in this guide may have snippets of commands to be run in your shell.
 When you see these, any line beginning with `$` is run as your normal user.
 Lines beginning with `#` are run as `root`. After either of these lines, there
 may be example output from the command.
+
+### Placeholders
+
+Some examples include text with placeholders. Placeholders indicate where you
+should substitute the appropriate information. For example:
+
+> ```
+> # ln -s /etc/sv/<service_name> /var/service/
+> ```
+
+This means you need to substitute the text `<service_name>` with the actual
+service name.

--- a/src/contributing/void-docs/style-guide.md
+++ b/src/contributing/void-docs/style-guide.md
@@ -75,6 +75,22 @@ and also not:
 vi /etc/fstab
 ```
 
+### Placeholders
+
+Placeholders indicate where the user should substitute the appropriate
+information. They should use angle brackets (`<` and `>`) and contain only
+lower-case text, with words separated by underscores. For example:
+
+```
+# ln -s /etc/sv/<service_name> /var/service/
+```
+
+and not:
+
+```
+# ln -s /etc/sv/[SERVICENAME] /var/service/
+```
+
 ## Links
 
 Link text should not include sentence-level punctuation. For example:


### PR DESCRIPTION
This PR is based on extant usage patterns in the Handbook.