### PR TITLE
xorg.md: change table to list

### DIFF
--- a/src/config/graphical-session/xorg.md
+++ b/src/config/graphical-session/xorg.md
@@ -58,17 +58,7 @@ repository](../../xbps/repositories/official/nonfree.md).
 A number of input drivers are available for Xorg. If `xorg-minimal` was
 installed and a device is not responding, or behaving unexpectedly, a different
 driver may correct the issue. These drivers can grab everything from power
-buttons to mice and keyboards.
-
-| Driver                 |
-|------------------------|
-| `xf86-input-evdev`     |
-| `xf86-input-joystick`  |
-| `xf86-input-libinput`  |
-| `xf86-input-mtrack`    |
-| `xf86-input-synaptics` |
-| `xf86-input-vmmouse`   |
-| `xf86-input-wacom`     |
+buttons to mice and keyboards. They are provided by the `xf86-input-*` packages.
 
 ## Xorg Configuration
 


### PR DESCRIPTION
This section previously generated an html table but it does not contain tabular
data. It has been changed to an unordered list.