### PR TITLE
pulseaudio: Correct information re. D-BUS.

### DIFF
--- a/src/config/media/pulseaudio.md
+++ b/src/config/media/pulseaudio.md
@@ -1,7 +1,8 @@
 # PulseAudio
 
-PulseAudio depends on a `dbus` system daemon. Make sure the `dbus` service is
-enabled.
+Depending on which applications you use, you might need to provide PulseAudio
+with a D-BUS session bus (e.g. via `dbus-run-session`) or a D-BUS system bus
+(via the `dbus` service).
 
 For applications which use ALSA directly and don't support PulseAudio, the
 `alsa-plugins-pulseaudio` package can make them use PulseAudio through ALSA.


### PR DESCRIPTION
This PR is based on a combination of [this diagram](https://gavv.github.io/articles/pulseaudio-under-the-hood/#high-level-components) (referenced from the PulseAudio documentation [here](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/)), together with some light testing in a VM. 