### PR TITLE
adding headings for runit in handbook

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,7 +17,7 @@
 - [Configuration](./config/index.md)
    - [Locales](./config/locales.md)
    - [Users and Groups](./config/users-and-groups.md)
-   - [Services And Daemons](./config/services/index.md)
+   - [Services And Daemons - runit](./config/services/index.md)
       - [Per-User Services](./config/services/user-services.md)
       - [Logging](./config/services/logging.md)
    - [rc files](./config/rc-files.md)

--- a/src/config/services/index.md
+++ b/src/config/services/index.md
@@ -1,4 +1,4 @@
-# Services and Daemons
+# Services and Daemons - runit
 
 Void uses the [runit(8)](https://man.voidlinux.org/runit.8) supervision suite to
 run system services and daemons.


### PR DESCRIPTION
I've changed the headings referring to service management and daemons to include a reference to runit. This makes it easier to find the section for managing runit in the handbook.