### PR TITLE
src/theme/css/general.css: correction

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -276,7 +276,7 @@ body {
 /* 300px + 800px + 2*90px + 15px */
 @media only screen and (min-width: 1295px) {
 	.sidebar-visible #nav-wide-wrapper {
-		max-width: auto;
+		max-width: none;
 		margin: 0;
 	}
 	.sidebar-visible .nav-chapters {
@@ -294,7 +294,7 @@ body {
 /* 800px + 2*90px + 15px */
 @media only screen and (min-width: 995px) {
 	.sidebar-hidden #nav-wide-wrapper {
-		max-width: auto;
+		max-width: none;
 		margin: 0;
 	}
 	.sidebar-hidden .nav-chapters {


### PR DESCRIPTION
http://jigsaw.w3.org/css-validator/validator?uri=https%3A%2F%2Fdocs.voidlinux.org%2Fcss%2Fgeneral.css&profile=css3svg&usermedium=all&warning=1&vextwarning=&lang=en

general.css sets `max-width: auto;`. the value that removes a `max-width` is `none`.

This does cause Firefox to interpret these lines of css differently so I think this merits some more scrutiny before it's merged. This ends up changing the actual width of the box in question. But its children are all floated, so it doesn't seem to make any difference.