### PR TITLE
about/index: Multiple changes.

### DIFF
--- a/src/about/index.md
+++ b/src/about/index.md
@@ -6,8 +6,9 @@ documentation effectively.
 
 Void is an independent, [rolling
 release](https://en.wikipedia.org/wiki/Rolling_release) Linux distribution,
-developed from scratch and not as a fork of any other distribution. There are a
-few features that make Void unique:
+developed from scratch rather than as a fork, with a focus on stability over
+[bleeding-edge](https://en.wikipedia.org/wiki/Bleeding_edge_technology). In
+addition, there are several features that make Void unique:
 
 - The [XBPS](https://github.com/void-linux/xbps) package manager, which is
    extremely fast, developed in-house, and performs checks when installing
@@ -22,12 +23,15 @@ few features that make Void unique:
    dedicated to the security, quality, and maintainability of this critical
    library.
 - [runit](../config/services/index.md) is used for
-   [init(8)](https://man.voidlinux.org/init.8). This allows Void to support musl
-   as a second libc choice, which would not be possible with
-   [systemd](https://www.freedesktop.org/wiki/Software/systemd/). A side effect
-   of this decision is an init system with clean and efficient operation, and a
-   small code base.
+   [init(8)](https://man.voidlinux.org/init.8) and service supervision. This
+   allows Void to support musl as a second libc choice, which would not be
+   possible with [systemd](https://www.freedesktop.org/wiki/Software/systemd/).
+   A side effect of this decision is a core system with clean and efficient
+   operation, and a small code base.
 
 Void is developed in the spare time of a handful of developers, and is generally
 considered stable enough for daily use. We do this for fun and hope that our
 work will be useful to others.
+
+The name "Void" comes from the C literal `void`. It was chosen rather randomly,
+and has no deeper meaning.


### PR DESCRIPTION
* Mention Void focusing on stability rather than on being bleeding-edge.
* Mention runit being used for service supervision as well as init.
* Mention origin of the "Void" name.

Partially addresses #337.