### PR TITLE
[WIP/RFC] install on mdraid, install on lvm2

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,6 +14,7 @@
    - [Advanced Installation](./installation/guides/index.md)
       - [Installation via chroot (x86/x86_64)](./installation/guides/chroot.md)
       - [Full Disk Encryption](./installation/guides/fde.md)
+      - [MDRAID](./installation/guides/mdraid.md)
    - [musl](./installation/musl.md)
 - [Configuration](./config/index.md)
    - [Locales](./config/locales.md)

--- a/src/installation/guides/index.md
+++ b/src/installation/guides/index.md
@@ -6,3 +6,4 @@ This section contains guides for more specific or complex use-cases.
 
 - [Installing Void via chroot (x86 or x86_64)](./chroot.md)
 - [Installing Void with Full Disk Encryption](./fde.md)
+- [MDRAID](./mdraid.md)

--- a/src/installation/guides/lvm2.md
+++ b/src/installation/guides/lvm2.md
@@ -1,0 +1,50 @@
+# LVM2
+
+[lvm(8)](https://man.voidlinux.org/lvm.8) is used to manage LVM2 logical
+volumes.  Install the package `lvm2`. The same functionality is available as a
+number of standalone commands for particular tasks, such as
+[vgcreate(8)](https://man.voidlinux.org/vgcreate.8),
+[lvcreate(8)](https://man.voidlinux.org/lvcreate.8).
+
+This guide is broken down into three steps to accomodate three different
+configurations:
+
+1. To set up logical volumes that are not mounted on `/` or a critical system
+   directory (such as `/boot` or `/usr`), follow only the first step.
+2. To set up a logical volume that is mounted on `/` with a separate `/boot`
+   partition that is not on a logical volume, follow the first and second steps.
+3. To set up a logical volume that is mounted on `/` with `/boot` also in a
+logical volume
+
+Note: If following steps 2 or 3 while installing Void, be sure to install lvm2
+on both the host operating system and the chroot.
+
+## Step 1. Create Volumes
+
+Create volume groups and logical volumes as desired using
+[vgcreate(8)](https://man.voidlinux.org/vgcreate.8) and
+[lvcreate(8)](https://man.voidlinux.org/lvcreate.8) respectively.
+
+LVM2 volumes are automatically detected and configured, either at boot time or
+when the disks are connected. Volumes do not need to be configured in
+[lvm.conf(5)](https://man.voidlinux.org/lvm.conf.5). Volumes
+are accessible as `/dev/mapper/<volume-group>-<volume-name>`
+
+Format volumes as desired. Add corresponding entries to
+[fstab(5)](https://man.voidlinux.org/fstab.5). LVM2 volumes can be safely
+identified `/dev/mapper/<group>-<name>` in fstab.
+
+## Step 2. Configure Dracut
+
+Configure dracut to automatically assemble logical volumes in early userspace by
+creating a [dracut.conf(5)](https://man.voidlinux.org/dracut.conf.5) file:
+
+```
+kernel_cmdline+=" rd.auto=1 "
+```
+
+## Step 3. Configure GRUB
+
+[Install GRUB](chroot.md#installing-grub). If `/boot` is moved into a logical
+volume, this step must be performed even if grub was previously installed.
+[Regenerate GRUB's configuration](../../config/kernel.md#install-hooks).

--- a/src/installation/guides/mdraid.md
+++ b/src/installation/guides/mdraid.md
@@ -1,0 +1,82 @@
+# MDRAID
+
+[mdadm(8)](https://man.voidlinux.org/mdadm.8) is used to manage arrays.
+Install the package `mdraid`.
+
+This guide is broken down into three steps to accomodate three different
+configurations:
+
+1. To set up a raid array that is not mounted on `/` or a critical system
+   directory (such as `/boot` or `/usr`), follow only the first step.
+2. To set up a raid array that is mounted on `/` with a separate `/boot`
+   partition that is not on raid, follow the first and second steps.
+3. To set up a raid array that is mounted on `/` without a separate `/boot`
+   partition, follow all three steps.
+
+Note: If following steps 2 or 3 while installing Void, be sure to install mdadm
+on both the host operating system and the chroot.
+
+## Step 1. Create Arrays
+
+Partition disks that will be used. No more than one partition per disk should be
+used per raid array. 
+
+UEFI users creating an array that include `/` and `/boot` should create an EFI
+System Partition (ESP) on every disk of exactly the same size. Create a raid
+array with the option `--level=1`. Format the array with
+[mkfs.vfat(8)](https://man.voidlinux.org/mkfs.fat.8) and make sure it is mounted
+as `/boot/efi`.
+
+Create a new mdraid array using `mdadm --create` The raid array is now
+accessible as `/dev/md<n>` (*n* is specified in the previous command). Creating
+an array requires writing a large amount of data to disk. This is done in the
+background, but reading from the device may be unreliable while it is ongoing.
+`cat /proc/mdstat` to check status.
+
+Write the active array information to
+[mdadm.conf(5)](https://man.voidlinux.org/mdadm.conf.5):
+
+```
+# mdadm --detail --scan >> /etc/mdadm.conf
+```
+
+Optionally partition `/dev/md<n>`. Partitions are identified as
+`/dev/md<n>p{1,2,...}`.
+
+Format as desired. Add corresponding entries to
+[fstab(5)](https://man.voidlinux.org/fstab.5). mdraid arrays can be safely
+identified as `/dev/md<n>` in fstab as long as the array is configured in
+mdadm.conf.  Without mdadm.conf, arrays can still be automatically detected but
+do not have stable names. In either case, filesystems can still be identified
+by their UUID, as reported by [blkid(8)](https://man.voidlinux.org/blkid.8).
+
+To monitor arrays, enable the `mdadm` service. Further configuration is
+necessary to receive mail from the service.
+
+## Step 2. Configure Dracut
+
+Configure dracut to automatically assemble raid arrays in early userspace by
+creating a [dracut.conf(5)](https://man.voidlinux.org/dracut.conf.5) file:
+
+```
+mdadmconf=yes
+kernel_cmdline+=" rd.auto=1 "
+```
+
+[Generate a new initramfs](../../config/kernel.md#install-hooks) before the
+system is rebooted.
+
+## Step 3. Configure GRUB
+
+[Install GRUB](chroot.md#installing-grub). If `/boot` is moved into a raid
+array, this step must be performed even if grub was previously installed.
+[Regenerate GRUB's configuration](../../config/kernel.md#install-hooks).
+
+BIOS users should run `grub-install` for every disk in the array.
+
+UEFI users should run `grub-install --removable` while `/boot/efi` is mounted as
+the raid array created for the EFI System Partition.
+
+**Warning:** do not let any other operating systems write to this EFI System
+Partition unless it is configured as an mdraid array. Operating systems without
+mdraid support can safely mount mdraid level-1 arrays read-only.


### PR DESCRIPTION
My goal is to find a format that will work for any "install void with root on ___" guides without repeating any information that's found in the manual installation guide. This PR covers mdraid and lvm2 right now, but if there's support for this I'll cover luks as well. (and probably cut out a lot of the mdraid stuff because now that I've written it I'm not really sure it's worth covering how to put your root on raid).

Right now, the guides have not been edited very much, or even spell checked. I'm not looking for feedback on that kind of thing yet, I'm more concerned with whether this structure works or not.

The guides are written just as documentation to mdraid/luks and don't explicitly refer to the installation guide. They are broken down into three steps: the first configures mdraid/lvm, the second configures dracut and the third configures grub. The same documentation should be usable for three configurations: non-root filesystems, root filesystem without /boot, or root filesystem and /boot. The instructions should make sense outside of the context of the installation guide, but it should also be obvious for those following along with the installation guide when these steps should be performed.