### PR TITLE
podman.md: Added containers and VMs section with starting podman doc …

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -50,6 +50,8 @@
       - [Configuring a New Printer](./config/print/config.md)
    - [Manual Pages](./config/man.md)
    - [Microcode](./config/microcode.md)
+   - [Containers and VMs](./config/containers_and_vms/index.md)
+      - [Podman](./config/containers_and_vms/podman.md)
 - [XBPS Package Manager](./xbps/index.md)
    - [Updating](./xbps/updating.md)
    - [Packages](./xbps/packages/index.md)

--- a/src/config/containers_and_vms/index.md
+++ b/src/config/containers_and_vms/index.md
@@ -1,0 +1,4 @@
+# Containers and VMs
+
+This section covers the setup of commonly used container and virtual machine
+programs

--- a/src/config/containers_and_vms/podman.md
+++ b/src/config/containers_and_vms/podman.md
@@ -1,0 +1,33 @@
+# Podman
+
+**Podman** is a daemonless engine for developing, managing, and running pods,
+containers, and container images.
+
+## Installation
+
+Install the `podman` package.
+
+## Checking installation
+
+To check your installation of podman, run the following command:
+
+`$ podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd`
+
+Then, open a Internet browser and navigate to `0.0.0.0:8080` in the address bar.
+If you see a message about a test page and apache server running, podman is
+running correctly.
+
+To see more podman commands, and walk through basic tutorials, see the [getting
+started](https://podman.io/getting-started/) page.
+
+## Troubleshooting
+
+### OCI runtime error
+
+You may receive the following message when you issue a podman command:
+
+```
+Error: container_linux.go:349: starting container process caused "process_linux.go:449: container init caused \"process_linux.go:378: setting rlimits for ready process caused \\\"error setting rlimit type 7: invalid argument\\\"\"": OCI runtime error
+```
+
+If this occurs, rerun the command with `sudo` privileges.


### PR DESCRIPTION
I am looking for a couple suggestions regarding this doc.
1) Should I add a section about the podman man pages? Seems like a good move.
2) Is it okay that the podman command to test the installation is something relating to fedora. It seems to be more an apache web server, and it is the one in the podman docs on their website. Did not know if the void team wanted it to be something a little more distro agonist.
   -- NOTE to self: add the command to stop the test container --> `sudo podman stop -l`
3) I do not like the error section in this. Saying to run a command as sudo to fix an error makes my blood pressure raise at least 10 points. I will absolutely edit that section (i see it more of a placeholder). I could use some guidance on what to put. The podman doc says
```
The code samples are intended to be run as a non-root user, and use sudo where root escalation is required.
```
They list the command for the test container as 
```
$ podman run -dt -p 8080:8080/tcp registry.fedoraproject.org/f29/httpd
```
Emphasis on the $. Note that command does return the documented error on my system. Their doc makes no reverence to editing permissions, groups etc to allow podman to run the above command as user. I could use some guidance on cleaning up that section.

After I have feedback, I will edit accordingly and resubmit!