### PR TITLE
repositories/index,guides/chroot: Multiple changes.

### DIFF
--- a/src/installation/guides/chroot.md
+++ b/src/installation/guides/chroot.md
@@ -81,14 +81,10 @@ Follow only one of the two following subsections.
 
 ### The XBPS Method
 
-[Select an XBPS mirror](../../xbps/repositories/mirrors/index.md). For
-simplicity, save this URL to a shell variable for later use. Append `/current`
-to this repository URL to install a glibc distribution, or `/current/musl` for a
-musl distribution.
-
-Note: musl binaries are not available for i686.
-
-For example, this is the URL for glibc from a Tier 1 server:
+Select a [mirror](../../xbps/repositories/mirrors/index.md) and use the
+[appropriate URL](../../xbps/repositories/index.md#the-main-repository) for the
+type of system you wish to install. For simplicity, save this URL to a shell
+variable for later use, e.g.:
 
 ```
 # REPO=https://alpha.de.repo.voidlinux.org/current

--- a/src/xbps/repositories/index.md
+++ b/src/xbps/repositories/index.md
@@ -8,7 +8,16 @@ which may also be signed.
 Note that, while local repositories do not require signatures, remote
 repositories *must* be signed.
 
-## Official Repositories
+## The main repository
+
+The locations of the main repository in relation to a base [mirror
+URL](./mirrors/index.md) are:
+
+- glibc: `/current`
+- musl: `/current/musl`
+- aarch64 and aarch64-musl: `/current/aarch64`
+
+## Subrepositories
 
 In addition to the main repository, which is enabled upon installation, Void
 provides other official repositories maintained by the Void project, but not


### PR DESCRIPTION
* index: Mention locations of main repository for different system types.
* chroot: Refer to new "main repository" subsection in `index`.

Partially addresses #358.