### PR TITLE
config/index: Change wording.

### DIFF
--- a/src/config/index.md
+++ b/src/config/index.md
@@ -1,3 +1,4 @@
 # Configuration
 
-Everything from basic network config to where to find tuning constants.
+This section and its subsections provide information about configuring your Void
+system.


### PR DESCRIPTION
The fact that mdBook requires every section to have an associated page creates annoyingly short pages such as this. We could add a "Section Contents" ToC to this page, but then i'd be concerned about the extra work keeping it in sync with the contents of SUMMARY. Suggestions for any other text that could flesh out this page to something more substantial?  