### PR TITLE
iwd: Tidy section.

### DIFF
--- a/src/config/network/iwd.md
+++ b/src/config/network/iwd.md
@@ -7,20 +7,16 @@ for Linux that aims to replace [WPA supplicant](./wpa_supplicant.md).
 
 Install the `iwd` package and enable the `dbus` and `iwd` services.
 
-> Note: To use EAP-TLS, EAP-TTLS, and EAP-PEAP based configurations, version
-> ≥4.20 of the kernel is required. Previous kernel versions do not include the
-> necessary cryptographic authentication modules.
-
 ## Usage
 
 The command-line client [iwctl(1)](https://man.voidlinux.org/iwctl.1) can be
 used to add, remove, and configure network connections. Commands can be passed
 as arguments; when run without arguments, it provides an interactive session. To
-list available commands, run either `iwctl help` or enter `help` at the
-interactive prompt.
+list available commands, run `iwctl help`, or run `iwctl` and enter `help` at
+the interactive prompt.
 
-> Note: By default, only the root user and those in the `wheel` group have
-> permission to operate `iwctl`.
+By default, only the root user and those in the `wheel` group have permission to
+operate `iwctl`.
 
 ## Configuration
 


### PR DESCRIPTION
* Remove now-unnecessary note about minimal kernel version.
* Convert note about wheel group membership to plain text.
* Improve phrasing.

Using `pandoc` to convert this section to a PDF results in an error due to the presence of '≥', but i assume that the note containing that character is no longer needed.