### PR TITLE
network-filesystems.md: changed wrong service names to run nfs

### DIFF
--- a/src/config/network-filesystems.md
+++ b/src/config/network-filesystems.md
@@ -8,8 +8,8 @@ To mount an NFS share, start by installing the `nfs-utils` and `sv-netmount`
 packages.
 
 Before mounting an NFS share, [enable](./services/index.md#enabling-services)
-the `statd`, `procbind`, and `sv-netmount` services. If the server supports
-`nfs4`, the `statd` service isn't necessary.
+the `statd`, `rpcbind`, and `netmount` services. If the server supports `nfs4`,
+the `statd` service isn't necessary.
 
 To mount an NFS share:
 


### PR DESCRIPTION
Correction for the wrong names of the services that need to be activated to use nfs. Someone mistook the package names for the service names.