### PR TITLE
add details for GRUB on BIOS and GPT

### DIFF
--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -98,8 +98,8 @@ create a partition (typically between 200MB-1GB) of type `EFI System`, which
 will be mounted at `/boot/efi`.
 
 If using BIOS, it is recommended you select MBR for the partition table.
-Advanced users may use GPT but will need to [create a special BIOS partition](./partitions.md#bios-system-notes) for
-`grub` to boot.
+Advanced users may use GPT but will need to [create a special BIOS
+partition](./partitions.md#bios-system-notes) for `grub` to boot.
 
 See the [Partitioning Notes](./partitions.md) for more details about
 partitioning your disk.

--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -98,7 +98,7 @@ create a partition (typically between 200MB-1GB) of type `EFI System`, which
 will be mounted at `/boot/efi`.
 
 If using BIOS, it is recommended you select MBR for the partition table.
-Advanced users may use GPT but will need to create a special BIOS partition for
+Advanced users may use GPT but will need to [create a special BIOS partition](./partitions.md#bios-system-notes) for
 `grub` to boot.
 
 See the [Partitioning Notes](./partitions.md) for more details about

--- a/src/installation/live-images/partitions.md
+++ b/src/installation/live-images/partitions.md
@@ -43,7 +43,7 @@ following table has recommendations for swap partition size.
 
 | System RAM | Recommended swap space | Swap space if using hibernation |
 |------------|------------------------|---------------------------------|
-| &lt; 2GB   | 2x the amount of RAM   | 3x the amount of RAM            |
+| < 2GB      | 2x the amount of RAM   | 3x the amount of RAM            |
 | 2-8GB      | Equal to amount of RAM | 2x the amount of RAM            |
 | 8-64GB     | At least 4GB           | 1.5x the amount of RAM          |
 | 64GB       | At least 4GB           | Hibernation not recommended     |

--- a/src/installation/live-images/partitions.md
+++ b/src/installation/live-images/partitions.md
@@ -19,9 +19,12 @@ The following sections will detail the options for partition configuration.
 ## BIOS system notes
 
 It is recommended that you create an MBR partition table if you are using a BIOS
-boot system. This will limit the number of partitions you create to four. It is
-possible to install a GPT partition table on a BIOS system, but grub will need a
-special partition to boot properly.
+boot system. This will limit the number of partitions you create to four.
+
+It is possible to install a GPT partition table on a BIOS system, but grub will
+need a special partition to boot properly. To do this, create a partition of
+1MB at the beginning of your disk, and give it the type `BIOS boot`. This
+partition shall not have a filesystem; grub should install successfully.
 
 ## UEFI system notes
 

--- a/src/installation/live-images/partitions.md
+++ b/src/installation/live-images/partitions.md
@@ -21,10 +21,10 @@ The following sections will detail the options for partition configuration.
 It is recommended that you create an MBR partition table if you are using a BIOS
 boot system. This will limit the number of partitions you create to four.
 
-It is possible to install a GPT partition table on a BIOS system, but grub will
-need a special partition to boot properly. To do this, create a partition of
-1MB at the beginning of your disk, and give it the type `BIOS boot`. This
-partition shall not have a filesystem; grub should install successfully.
+It is possible to use a GPT partition table on a BIOS system, but grub will
+require a special partition to boot properly. This partition should be at the
+beginning of your disk and have a size of 1MB, with type BIOS boot. Don't create
+any filesystem in it. GRUB should install successfully.
 
 ## UEFI system notes
 
@@ -43,7 +43,7 @@ following table has recommendations for swap partition size.
 
 | System RAM | Recommended swap space | Swap space if using hibernation |
 |------------|------------------------|---------------------------------|
-| < 2GB      | 2x the amount of RAM   | 3x the amount of RAM            |
+| &lt; 2GB   | 2x the amount of RAM   | 3x the amount of RAM            |
 | 2-8GB      | Equal to amount of RAM | 2x the amount of RAM            |
 | 8-64GB     | At least 4GB           | 1.5x the amount of RAM          |
 | 64GB       | At least 4GB           | Hibernation not recommended     |

--- a/src/installation/live-images/partitions.md
+++ b/src/installation/live-images/partitions.md
@@ -23,8 +23,9 @@ boot system. This will limit the number of partitions you create to four.
 
 It is possible to use a GPT partition table on a BIOS system, but grub will
 require a special partition to boot properly. This partition should be at the
-beginning of your disk and have a size of 1MB, with type BIOS boot. Don't create
-any filesystem in it. GRUB should install successfully.
+beginning of your disk and have a size of 1MB, with type `BIOS boot` (GUID
+`21686148-6449-6E6F-744E-656564454649`). Don't create any filesystem in it. GRUB
+should install successfully.
 
 ## UEFI system notes
 


### PR DESCRIPTION
Closes #425

Adds some details for GRUB with a BIOS system using a GPT partition table. The details add some clarity about what one should do if they want to install GRUB on a BIOS system with a GPT partition table instead of an MBR table.