### PR TITLE
kde.md: Add section on dolphin

### DIFF
--- a/src/config/graphical-session/kde.md
+++ b/src/config/graphical-session/kde.md
@@ -17,3 +17,17 @@ instead.
 If you wish to start an X-based session from the console, use
 [startx](./xorg.md#startx) to run `startplasma-x11`. For a Wayland-based
 session, run `startplasma-wayland` directly.
+
+## Dolphin
+
+Dolphin is the default file manager of the KDE desktop environment. It can be
+installed on its own by installing the `dolphin` package, or it can be installed
+as part of the `kde5-baseapps` meta-package.
+
+### Thumbnail Previews
+
+To enable thumbnail file previews, install the `kdegraphics-thumbnailers`
+package. If you want video thumbnails, the `ffmpegthumbs` package is also
+necessary. Enable previews in "Control" -> "Configure Dolphin" -> "General" ->
+"Previews" by checking the corresponding boxes. File previews will be shown for
+the selected file types after clicking "Preview" in Dolphin's toolbar.


### PR DESCRIPTION
This commit adds information from [the wiki page on dolphin](https://wiki.voidlinux.org/Dolphin) to the handbook page on KDE. The tracking issue (#327) mentions that this material might be good for the KDE section, so I ported it over as best as I could.