### PR TITLE
[RFC] history: add more interesting dates.

### DIFF
--- a/src/about/history.md
+++ b/src/about/history.md
@@ -1,10 +1,15 @@
 # History
 
-Knowledge of the ancients, grepped from the git logs themselves:
+Knowledge of the ancients, grepped from the Git logs themselves:
 
-- Sep 26 2008: first git import of
+- 2008-09-26: first Git import of
    [void-packages](https://github.com/void-linux/void-packages)
-- Aug 17 2009: first git import of [xbps](https://github.com/void-linux/xbps)
-- Mar 1 2013: first [musl](https://www.musl-libc.org/) toolchains added
-- Jul 14 2014: begin switching to [LibreSSL](https://www.libressl.org/)
-- Jul 28 2014: switch from systemd to [runit](http://smarden.org/runit/)
+- 2009-08-17: first Git import of [xbps](https://github.com/void-linux/xbps)
+- 2011-06-25: first systemd commit in void-packages
+- 2013-03-01: first [musl](https://www.musl-libc.org/) toolchains added
+- 2014-07-14: begin switching to [LibreSSL](https://www.libressl.org/)
+- 2014-07-28: switch from systemd to [runit](http://smarden.org/runit/)
+- 2015-07-09: full aarch64 support with `linux4.1`
+- 2018-07-06: first use of [Terraform for GitHub
+   permissions](https://github.com/void-linux/void-infrastructure/tree/master/terraform),
+   for increased transparency


### PR DESCRIPTION
Sources:

- systemd: ccc13eae418d9f827c4505202dc3eebaccfb00aa in void-packages
- aarch64: 0f3b729b0839581b8d84b544af5d13049a15ed9a in void-packages

@leahneukirchen do you think that's a reasonable date for aarch64?

I would like to add a few more dates:

- first in person meetup - depends on someone who knows that info
- full transition to handbook - we need to decide if the wiki is being spun back up
- switch to transparent infra - suggested by maldridge, would have to find a date for it

I would like to change the date format to something more reasonable, if there's consensus for it.