### PR TITLE
ci/format: add debug var to mdbook-linkcheck.

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -9,7 +9,7 @@ tar xvf ~/bin/linkcheck.tar.gz -C ~/bin
 
 echo "Checking links"
 
-~/bin/mdbook-linkcheck -s
+RUST_LOG=linkcheck=debug ~/bin/mdbook-linkcheck -s
 LINKCHECK=$?
 
 echo "Installing Go"


### PR DESCRIPTION
Temporary, will be used in order to help catch timeouts.