### PR TITLE
mdbook-latex: Fix incorrect generation of internal links.

### DIFF
--- a/res/mdbook-latex
+++ b/res/mdbook-latex
@@ -267,7 +267,7 @@ sub create_internal_link {
         $base = $1;
         $base = $current_directory . $base;
         $base = Cwd::abs_path("../../src/" . $base);
-        $base =~ s|^.+/void-docs/src/||;
+        $base =~ s|^.+/src/||;
         $base =~ s|.md||;
     }
     $base =~ s|/|-|g;


### PR DESCRIPTION
Addresses issue noted in #403 [here](https://github.com/void-linux/void-docs/pull/403#issuecomment-668347838) and #407 [here](https://github.com/void-linux/void-docs/issues/407#issuecomment-668361389).