### PR TITLE
installation, config: capitalize mentions of GRUB

### DIFF
--- a/src/installation/guides/fde.md
+++ b/src/installation/guides/fde.md
@@ -41,7 +41,7 @@ Device      Start       End   Sectors  Size Type
 /dev/sda2  264192 100663262 100399071 47.9G Linux filesystem
 ```
 
-Configure the encrypted volume. `cryptsetup` defaults to LUKS2, yet `grub`
+Configure the encrypted volume. `cryptsetup` defaults to LUKS2, yet GRUB
 currently only has support for LUKS1, so it is critical to force LUKS1. Keep in
 mind this will be `/dev/sda2` on EFI systems.
 

--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -99,7 +99,7 @@ will be mounted at `/boot/efi`.
 
 If using BIOS, it is recommended you select MBR for the partition table.
 Advanced users may use GPT but will need to [create a special BIOS
-partition](./partitions.md#bios-system-notes) for `grub` to boot.
+partition](./partitions.md#bios-system-notes) for GRUB to boot.
 
 See the [Partitioning Notes](./partitions.md) for more details about
 partitioning your disk.

--- a/src/installation/live-images/partitions.md
+++ b/src/installation/live-images/partitions.md
@@ -30,7 +30,7 @@ should then install itself successfully.
 ## UEFI system notes
 
 UEFI users are recommended to create a GPT partition table. UEFI booting with
-grub also requires a special partition of the type `EFI System` with a `vfat`
+GRUB also requires a special partition of the type `EFI System` with a `vfat`
 filesystem mounted at `/boot/efi`. A reasonable size for this partition could be
 between 200MB and 1GB. With this partition setup during the live image
 installation, the installer should successfully set up the bootloader
@@ -55,7 +55,7 @@ On most modern systems, a separate `/boot` partition is no longer necessary to
 boot properly. If you choose to use one, note that Void does not remove old
 kernels after updates by default and also that the kernel tends to increase in
 size with each new version, so plan accordingly (e.g. `/boot` with one Linux 5.x
-`x86_64` kernel and grub occupies about 60MB).
+`x86_64` kernel and GRUB occupies about 60MB).
 
 ## Other partitions
 


### PR DESCRIPTION
Fixes some inconsistencies in capitalization of GRUB throughout the book.

Did I title this PR correctly? :) 

Also, I noticed another inconsistency (in text): `GRUB` and GRUB. Is there a rule of thumb for choosing between the two? And should a new PR be made for correcting it?