### PR TITLE
user-services.md: Added alias to manage user services.

### DIFF
--- a/src/config/services/user-services.md
+++ b/src/config/services/user-services.md
@@ -45,5 +45,4 @@ ok: run: gpg-agent: (pid 19818) 0s
 ```
 
 It may be convenient to adapt the above example to a shell alias such as
-`svl="SVDIR=~/service sv"` for your user shell. This makes management of user
-services trivial.
+`svl="SVDIR=~/service sv"`. This makes management of user services trivial.

--- a/src/config/services/user-services.md
+++ b/src/config/services/user-services.md
@@ -43,3 +43,13 @@ run: /home/duncan/service/ssh-agent: (pid 900) 33102s
 $ SVDIR=~/service sv restart gpg-agent
 ok: run: gpg-agent: (pid 19818) 0s
 ```
+
+For your convenience, an alias for local service management may be added to your
+shell's init script. If the default Bash shell is used, add the following line
+to the `~/.bashrc` file:
+
+... alias svl="SVDIR=~/service sv" ...
+
+Local services may now be managed using the alias `svl`. It will accept all the
+same arugments that vanilla [sv](./index.md#basic-usage) does, but `svl` will
+check the user services directory instead.

--- a/src/config/services/user-services.md
+++ b/src/config/services/user-services.md
@@ -44,12 +44,6 @@ $ SVDIR=~/service sv restart gpg-agent
 ok: run: gpg-agent: (pid 19818) 0s
 ```
 
-For your convenience, an alias for local service management may be added to your
-shell's init script. If the default Bash shell is used, add the following line
-to the `~/.bashrc` file:
-
-... alias svl="SVDIR=~/service sv" ...
-
-Local services may now be managed using the alias `svl`. It will accept all the
-same arugments that vanilla [sv](./index.md#basic-usage) does, but `svl` will
-check the user services directory instead.
+It may be convenient to adapt the above example to a shell alias such as
+`svl="SVDIR=~/service sv"` for your user shell. This makes management of user
+services trivial.


### PR DESCRIPTION
The manual suggests setting the $SVDIR variable before calling `sv` on a user service directory. One such way to make user service management more convenient is to add an alias to your shell's init script. I've added an example of this using the alias `svl` to the relevant handbook page.