### PR TITLE
connman.md: Add connection workflow

### DIFF
--- a/src/config/network/connman.md
+++ b/src/config/network/connman.md
@@ -15,10 +15,27 @@ Finally, enable the `connmand` service.
 
 ## Configuring ConnMan
 
+### ConnMan CLI
+
 The `connman` package includes a command line tool,
 [connmanctl(1)](https://man.voidlinux.org/connmanctl.1) to control network
 settings. If you do not provide any commands, `connmanctl` starts as an
 interactive shell.
+
+Establishing a connection to an access point using the `connmanctl` interactive
+shell might look as follows:
+
+```
+# connmanctl
+> enable wifi
+> agent on
+> scan wifi
+> services
+> connect wifi_<uniqueid>
+> exit
+```
+
+### ConnMan Front-End Tools
 
 There are many other front-ends to ConnMan, including `connman-ui` for system
 trays, `connman-gtk` for GTK, `cmst` for QT and `connman-ncurses` for ncurses


### PR DESCRIPTION
**Description**
This PR pulls in the wifi connection workflow from the old connman wiki page.

**Note**
> While this handbook does not provide a large amount of copy and paste configuration instructions, it does provide links to the man pages for the referenced software wherever possible.

Not sure if this addition is in-line with the ethos outlined here on the "About This Handbook" page, but I have found that including this in the docs can be very handy. Personally, if I'm browsing this page it's usually from mobile while I'm looking for a quick reminder to get my real system back up and connected, and it's nice to have the workflow outlined right there.
