### PR TITLE
repositories/index: Add man page link.

### DIFF
--- a/src/xbps/repositories/index.md
+++ b/src/xbps/repositories/index.md
@@ -71,8 +71,9 @@ Once enabled, symbols may be obtained for `<package>` by installing
 
 #### Finding debug dependencies
 
-The `xtools` package contains the `xdbg` utility to retrieve a list of debug
-packages, including dependencies, for a package:
+The `xtools` package contains the [xdbg(1)](https://man.voidlinux.org/xtools.1)
+utility to retrieve a list of debug packages, including dependencies, for a
+package:
 
 ```
 $ xdbg bash


### PR DESCRIPTION
From what i can tell, this PR will allow #107, which has now been open for a year, to be closed.

Link goes to `xtools.1`, since linking to `xdbg.1` won't work.
