### PR TITLE
<various>: Remove unnecessary blockquotes.

### DIFF
--- a/src/config/bluetooth.md
+++ b/src/config/bluetooth.md
@@ -21,9 +21,9 @@ Then, add your user to the `bluetooth` group and restart the `dbus` service, or
 simply reboot the system. Note that restarting the `dbus` service may kill
 processes making use of it.
 
-> Note: To use an audio device such as a wireless speaker or headset, ALSA users
-> need to install the `bluez-alsa` package, while
-> [PulseAudio](./media/pulseaudio.md) users do not need any additional software.
+To use an audio device such as a wireless speaker or headset, ALSA users need to
+install the `bluez-alsa` package. [PulseAudio](./media/pulseaudio.md) users do
+not need any additional software.
 
 ## Usage
 

--- a/src/config/graphical-session/graphics-drivers/intel.md
+++ b/src/config/graphical-session/graphics-drivers/intel.md
@@ -7,10 +7,9 @@ dependency. If you installed a version-specific kernel package (e.g.,
 
 ## OpenGL
 
-Install the Mesa DRI package, `mesa-dri`.
-
-> Note: This is already included in the `xorg` meta-package, but it is needed
-> when installing xorg via `xorg-minimal` or for running a Wayland compositor.
+OpenGL requires the Mesa DRI package, `mesa-dri`. This is provided by the `xorg`
+meta-package, but will need to be installed manually when using the
+`xorg-minimal` package or running a Wayland compositor.
 
 ## Vulkan
 

--- a/src/config/users-and-groups.md
+++ b/src/config/users-and-groups.md
@@ -28,9 +28,9 @@ output of `chsh -l`, which provides a list of installed shells.
 
 ## sudo
 
-> Note: [sudo(8)](https://man.voidlinux.org/sudo.8) is installed by default but
-> may not be configured. It is only necessary to configure sudo if you wish to
-> use it.
+[sudo(8)](https://man.voidlinux.org/sudo.8) is installed by default, but might
+not be configured appropriately for your needs. It is only necessary to
+configure sudo if you wish to use it.
 
 Use [visudo(8)](https://man.voidlinux.org/visudo.8) as root to edit the
 [sudoers(5)](https://man.voidlinux.org/sudoers.5) file.


### PR DESCRIPTION
These appear to be the final few remaining blockquote usages that don't adhere to the style guide, other than the one in `external-applications.md`, which is being addressed in #469.