### PR TITLE
platforms: mention that rbpi kernels disable memcg by default

### DIFF
--- a/src/installation/guides/arm-devices/platforms.md
+++ b/src/installation/guides/arm-devices/platforms.md
@@ -85,3 +85,12 @@ configuration. It should show:
 $ i2cdetect -l
 i2c-1i2c          bcm2835 I2C adapter                 I2C adapter
 ```
+
+### Memory cgroup
+
+The kernel from the `rpi-kernel` package [disables the memory cgroup by
+default](https://github.com/raspberrypi/linux/commit/9b0efcc1ec497b2985c6aaa60cd97f0d2d96d203#diff-f1d702fa7c504a2b38b30ce6bb098744).
+
+This breaks workloads which use containers. Therefore, if you want to use
+containers on your Raspberry Pi, you need to enable memory cgroups by adding
+`cgroup_enable=memory` to `/boot/cmdline.txt`.


### PR DESCRIPTION
The raspberry pi kernel disables memcg by default which breaks containers.

This commit explains how to re-enable memory cgroups.
