### PR TITLE
mirrors: remove dk.archive.ubuntu.com

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -37,7 +37,6 @@ sub-repository.
 | <https://mirror.aarnet.edu.au/pub/voidlinux/>      | AU: Canberra      |
 | <https://ftp.swin.edu.au/voidlinux/>               | AU: Melbourne     |
 | <https://void.cijber.net/>                         | EU: Amsterdam, NL |
-| <http://dk.archive.ubuntu.com/voidlinux/>          | EU: Denmark       |
 | <http://ftp.dk.xemacs.org/voidlinux/>              | EU: Denmark       |
 | <https://mirrors.dotsrc.org/voidlinux/>            | EU: Denmark       |
 | <https://quantum-mirror.hu/mirrors/pub/voidlinux/> | EU: Hungary       |


### PR DESCRIPTION
This mirror is just a different address for mirrors.dotsrc.org

Before submitting a pull request, please read [CONTRIBUTING](./CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
