### PR TITLE
graphics-drivers/intel: mention DDX conflicts

### DIFF
--- a/src/config/graphical-session/graphics-drivers/intel.md
+++ b/src/config/graphical-session/graphics-drivers/intel.md
@@ -41,3 +41,8 @@ cmdline](../../kernel.md#cmdline). This problem is expected to happen on the
 Broadwell generation of internal GPUs. If you have another internal GPU and your
 issues are fixed by this kernel option, you should file a bug reporting the
 problem to kernel developers.
+
+For newer Intel chipsets, the [DDX](../xorg.md#ddx) drivers may interfere with
+correct operation. This is characterized by graphical acceleration not working
+and general graphical instability. If this is the case, try removing all
+`xf86-video-*` packages.


### PR DESCRIPTION
I just spent several hours trying to troubleshoot this, so I figure its worth a callout.  It wasn't immediately obvious to me that the DDX drivers and the more specific modesetting drivers don't conflict and manual intervention is needed to put the right set on a machine.

I'm still not entirely sure which classes of intel machines are affected by this, so I added it to troubleshooting rather than the driver selection section above.