### PR TITLE
mirrors/index: clean inactive and repeated mirrors

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -40,12 +40,10 @@ sub-repository.
 | <http://ftp.dk.xemacs.org/voidlinux/>              | EU: Denmark       |
 | <https://mirrors.dotsrc.org/voidlinux/>            | EU: Denmark       |
 | <https://quantum-mirror.hu/mirrors/pub/voidlinux/> | EU: Hungary       |
-| <https://mirror.i-novus.ru/mirrors/voidlinux/>     | EU: Ireland       |
 | <http://ftp.debian.ru/mirrors/voidlinux/>          | EU: Russia        |
 | <https://mirror.yandex.ru/mirrors/voidlinux/>      | EU: Russia        |
 | <https://cdimage.debian.org/mirror/voidlinux/>     | EU: Sweden        |
 | <https://ftp.acc.umu.se/mirror/voidlinux/>         | EU: Sweden        |
-| <https://ftp.gnome.org/mirror/voidlinux/>          | EU: Sweden        |
 | <https://ftp.lysator.liu.se/pub/voidlinux/>        | EU: Sweden        |
 | <https://ftp.sunet.se/mirror/voidlinux/>           | EU: Sweden        |
 


### PR DESCRIPTION
ftp.gnome.org == ftp.acc.umu.se