### PR TITLE
session management: add seatd

### DIFF
--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -40,3 +40,15 @@ service, as waiting for a D-Bus activation can lead to issues.
 There is an alternative D-Bus configuration which takes advantage of elogind for
 features such as seat detection. It requires installing the `dbus-elogind`,
 `dbus-elogind-libs` and `dbus-elogind-x11` packages.
+
+## seatd
+
+[seatd(1)](https://man.voidlinux.org/seatd.1) is a minimal seat management
+daemon and an alternative to elogind.
+
+To use it, install the `seatd` package and enable its service. If you want
+non-root users to be able to access the seatd session, add them to the `_seatd`
+group.
+
+Note that, unlike elogind, seatd doesn't doesn't do anything besides managing
+seats.


### PR DESCRIPTION
`check.sh` currently reports HTTP 404 for some mirrors, which I believe will be solved by #520 , and for the seatd manpage, which will be fixed by adding seatd to void-packages. 

This is my first attempt at contributing to the docs, so any feedback is welcome.