### PR TITLE
Create release process, document it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mandoc/
 res/void-docs
 res/void-docs.1
 res/handbook-cover.png
+*.tar.gz

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+# Making a release
+
+The sources for the Void Handbook are used in two ways:
+
+- Generating the online documentation in <https://docs.voidlinux.org/>;
+- Transpilation into multiple formats for distribution in the `void-docs`
+   package.
+
+For the latter, we currently depend on the `pandoc` utility, which unfortunately
+isn't available on all platforms that Void supports. Therefore, to allow the
+`void-docs` package to be created successfully on any platform, we distribute a
+tarball with pre-generated artifacts.
+
+In order to generate this tarball, which should be included in all Void Docs
+release, the following steps must be run:
+
+- Run `res/build.sh` to build all of the artifacts.
+- Run `res/tarball.sh` to generate the distribution tarball.
+
+Then, someone with a generated tarball will have to:
+
+- Unpack the tarball itself;
+- Unpack the `artifacts.tar.gz` tarball inside it;
+- Run `res/build.sh` with the `ONLY_VOID_DOCS` environment variable set to `1`;
+- Run `res/install.sh` with the appropriate `PREFIX` and `DESTDIR` environment
+   variables.

--- a/res/build.sh
+++ b/res/build.sh
@@ -5,6 +5,12 @@
 set -e
 PATH="$PWD/res:$PATH"
 
+# Build script
+echo "Building void-docs script and man page"
+sed -e "s,@PREFIX@,$PREFIX," res/void-docs.in > res/void-docs
+sed -e "s,@PREFIX@,$PREFIX," res/void-docs.1.in > res/void-docs.1
+[ -n "$ONLY_VOID_DOCS" ] && exit
+
 # Build HTML mdbook
 echo "Building mdBook"
 mdbook build
@@ -21,11 +27,6 @@ fd "\.md" ./ -x pandoc \
     -o "../mandoc/{.}.7" "{}"
 
 cd -
-
-# Build script
-echo "Building void-docs script and man page"
-sed -e "s,@PREFIX@,$PREFIX," res/void-docs.in > res/void-docs
-sed -e "s,@PREFIX@,$PREFIX," res/void-docs.1.in > res/void-docs.1
 
 # Build PDF
 

--- a/res/tarball.sh
+++ b/res/tarball.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+tag="${1?Please specify a tag}"
+
+# archive all artifacts into a separate zip, because
+# git-archive can't really handle this
+tar cvf artifacts.tar.gz mandoc/ book/
+
+git archive --verbose --add-file=artifacts.tar.gz \
+	--output="void-docs-$tag.tar.gz" "$tag"


### PR DESCRIPTION
The idea here is to allow the `void-docs` package to be built without any special tools, being the least portable one `pandoc`.