### PR TITLE
mirrors: remove maakpain.

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -32,7 +32,6 @@ sub-repository.
 | <https://mirrors.bfsu.edu.cn/voidlinux/>           | Asia: China       |
 | <https://mirrors.cnnic.cn/voidlinux/>              | Asia: China       |
 | <https://mirrors.tuna.tsinghua.edu.cn/voidlinux/>  | Asia: China       |
-| <https://mirror.maakpain.kro.kr/void/>             | Asia: Seoul, SK   |
 | <https://void.webconverger.org/>                   | Asia: Singapore   |
 | <https://mirror.aarnet.edu.au/pub/voidlinux/>      | AU: Canberra      |
 | <https://ftp.swin.edu.au/voidlinux/>               | AU: Melbourne     |


### PR DESCRIPTION
This mirror can no longer be reached.

Removing https://void.webconverger.org has also been suggested (it's about 2 months out of date), but it could still be useful as a source of live images.

Before submitting a pull request, please read [CONTRIBUTING](./CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
