### PR TITLE
res/build.sh: use lowdown instead of pandoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Void packages:
 
 - `mdBook`
 - `findutils`
-- `pandoc`
+- `lowdown` (version 0.8.1 or greater)
 - `texlive`
 - `perl`
 - `perl-JSON`


### PR DESCRIPTION
Given that pandoc is a haskell program, depending on it is bad due to
bootstrap and general platform compatibility concerns.

The ideal build will have the git repository available to it; builds
without the git repo will be missing date info from the man pages.