### PR TITLE
 theme/css/general.css: prevent tables from breaking mobile page width

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -55,6 +55,8 @@ li.js-unavailable {
 
 table {
 	border-collapse: collapse;
+	display: block;
+	overflow-y: auto;
 }
 table td {
 	padding: 3px 20px;
@@ -267,8 +269,9 @@ body {
 	width: 100%;
 }
 #page-wrapper {
-	width: 100%;
-	padding: 0 10px;
+	--content-padding: 10px;
+	padding: 0 var(--content-padding);
+	width: calc(100% - var(--content-padding) * 2);
 }
 #search-wrapper,
 #page-wrapper main {
@@ -315,6 +318,9 @@ body {
 		align-content: center;
 		display: flex;
 		flex-direction: column;
+	}
+	table {
+		display: table;
 	}
 }
 


### PR DESCRIPTION
Constrain tables to the page width and make content scrollable. Do not restrict table size large screens (when navigation sidebar is displayed by default).

# Before

Screenshot of [a page](https://docs.voidlinux.org/installation/live-images/index.html) currently live as seen on a phone (zoomed out):

<img width="375" alt="screenshot before" src="https://user-images.githubusercontent.com/4586410/108127953-55bbf800-70ac-11eb-8f19-892308d387fe.png">

# After

Screenshot of the same page with a scrolled table (not visible, but also "zoomed out"):

<img width="375" alt="screenshot after" src="https://user-images.githubusercontent.com/4586410/108128064-8308a600-70ac-11eb-8482-fcc244335217.png">
