### PR TITLE
mirrors/index: add SJTUG mirror

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -32,7 +32,7 @@ sub-repository.
 | <https://mirrors.bfsu.edu.cn/voidlinux/>           | Asia: China       |
 | <https://mirrors.cnnic.cn/voidlinux/>              | Asia: China       |
 | <https://mirrors.tuna.tsinghua.edu.cn/voidlinux/>  | Asia: China       |
-| <https://mirror.sjtu.edu.cn/voidlinux/>.           | Asia: China       |
+| <https://mirror.sjtu.edu.cn/voidlinux/>            | Asia: China       |
 | <https://mirror.maakpain.kro.kr/void/>             | Asia: Seoul, SK   |
 | <https://void.webconverger.org/>                   | Asia: Singapore   |
 | <https://mirror.aarnet.edu.au/pub/voidlinux/>      | AU: Canberra      |

--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -32,6 +32,7 @@ sub-repository.
 | <https://mirrors.bfsu.edu.cn/voidlinux/>           | Asia: China       |
 | <https://mirrors.cnnic.cn/voidlinux/>              | Asia: China       |
 | <https://mirrors.tuna.tsinghua.edu.cn/voidlinux/>  | Asia: China       |
+| <https://mirror.sjtu.edu.cn/voidlinux/>.           | Asia: China       |
 | <https://mirror.maakpain.kro.kr/void/>             | Asia: Seoul, SK   |
 | <https://void.webconverger.org/>                   | Asia: Singapore   |
 | <https://mirror.aarnet.edu.au/pub/voidlinux/>      | AU: Canberra      |


### PR DESCRIPTION
We would like to add SJTUG mirror for Void Linux.

Country: China
Organization or Name: Shanghai Jiao Tong University Linux User Group (SJTUG)
Contact Name: SJTUG
Contact Email: sjtug-mirror-maintainers@googlegroups.com
Mirror URLs: https://mirror.sjtu.edu.cn/voidlinux
Bandwidth: 1Gbps
Supports IPv6: No

Our mirror infrastructure works as follows: we scan file list from Void Linux rsync endpoint, download them through HTTP, and store them on a self-hosted s3-like service. If users access https://mirror.sjtu.edu.cn/voidlinux , they will be redirected to http://s3.jcloud.sjtu.edu.cn/899a892efef34b1b944a19981040f55b-oss01/voidlinux , which contains actual data. We have ensured that it really works for xbps package manager by using a [docker image](https://github.com/sjtug/mirror-test-scripts/pull/18).