### PR TITLE
rc-files.md: fixed setfont man link

### DIFF
--- a/src/config/rc-files.md
+++ b/src/config/rc-files.md
@@ -40,7 +40,7 @@ Specifies which font to use for the Linux console. Available fonts are listed in
 FONT=eurlatgr
 ```
 
-For further details, refer to [setfont(1)](https://man.voidlinux.org/setfont.1).
+For further details, refer to [setfont(8)](https://man.voidlinux.org/setfont.8).
 
 ## rc.local
 


### PR DESCRIPTION
This commit fixes an incorrect man page link for setfont. Closes #551.