### PR TITLE
pipewire.md: warn about XDG_RUNTIME_DIR

### DIFF
--- a/src/config/graphical-session/wayland.md
+++ b/src/config/graphical-session/wayland.md
@@ -80,15 +80,9 @@ compositors, and is installed as a dependency for most of them. Its package is
 
 ## Configuration
 
-The Wayland library uses the `XDG_RUNTIME_DIR` environment variable to determine
-the directory for the Wayland socket.
-
-Install `elogind` as your [session manager](../session-management.md) to
-automatically setup `XDG_RUNTIME_DIR`.
-
-Alternatively, manually set the environment variable through the shell. Make
-sure to create a dedicated user directory and set its permissions to `700`. A
-good default location is `/run/user/$(id -u)`.
+The Wayland library requires the
+[`XDG_RUNTIME_DIR`](../session-management.html#xdg_runtime_dir) environment
+variable to determine the directory for the Wayland socket.
 
 It is also possible that some applications use the `XDG_SESSION_TYPE`
 environment variable in some way, which requires that you set it to `wayland`.

--- a/src/config/media/pipewire.md
+++ b/src/config/media/pipewire.md
@@ -64,3 +64,9 @@ on glibc-based systems:
 # echo "/usr/lib/pipewire-0.3/jack" > /etc/ld.so.conf.d/pipewire-jack.conf
 # ldconfig
 ```
+
+## Troubleshooting
+
+The Pulseaudio replacement requires the
+[`XDG_RUNTIME_DIR`](../session-management.html#xdg_runtime_dir) environment
+variable to work correctly.

--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -52,3 +52,17 @@ non-root users to be able to access the seatd session, add them to the `_seatd`
 group.
 
 Note that, unlike elogind, seatd doesn't do anything besides managing seats.
+
+## XDG_RUNTIME_DIR
+
+`XDG_RUNTIME_DIR` is an environment variable defined by the [XDG Base Directory
+Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+Its value sets the path to the base directory where programs should store
+user-specific runtime files.
+
+Install [elogind](#elogind) as your session manager to automatically set up
+`XDG_RUNTIME_DIR`.
+
+Alternatively, manually set the environment variable through the shell. Make
+sure to create a dedicated user directory and set its permissions to `700`. A
+good default location is `/run/user/$(id -u)`.


### PR DESCRIPTION
Particularly nasty because no clear error messages are shown. Tripped up quite some users on IRC and [reddit](https://old.reddit.com/r/voidlinux/comments/nq3suy/pipewirepulse_and_void_linux_and_a_pile_of_other/)
