### PR TITLE
Remove mirror mirrors.hushan.tech.

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -50,12 +50,6 @@ sub-repository.
 | <https://ftp.sunet.se/mirror/voidlinux/>           | EU: Sweden        |
 | <https://mirror.clarkson.edu/voidlinux/>           | USA: New York     |
 
-### Region-locked mirrors
-
-| Repository                                    | Location    |
-|-----------------------------------------------|-------------|
-| <https://mirrors.hushan.tech:44300/voidlinux> | Asia: China |
-
 ## Tor Mirrors
 
 Void Linux is also mirrored on the Tor network. See [Using Tor


### PR DESCRIPTION
Hi.
As of the time I put up a mirror for Void Linux, download speed was miserable and there wasn't any mirror in China. But things have improved since then. Now three universities have made their contribution in hosting Void Linux for users in China. It looks like there's no need of hosting it on my home fiber anymore.

Thanks to Void developers for your great project!