### PR TITLE
ssd.md: Sync default fstrim cron configuration with util-linux upstream(systemd timer).

### DIFF
--- a/src/config/ssd.md
+++ b/src/config/ssd.md
@@ -25,7 +25,7 @@ To automate running TRIM, use cron or add the `discard` option to `/etc/fstab`.
 
 ## Periodic TRIM with cron
 
-Add the following lines to `/etc/cron.daily/fstrim`:
+Add the following lines to `/etc/cron.weekly/fstrim`:
 
 ```
 #!/bin/sh
@@ -36,7 +36,7 @@ fstrim /
 Finally, make the script executable:
 
 ```
-# chmod u+x /etc/cron.daily/fstrim
+# chmod u+x /etc/cron.weekly/fstrim
 ```
 
 ## Continuous TRIM with fstab discard


### PR DESCRIPTION
Recommendations for "quick-setup" scripts should reflect considerations from util-linux upstream ([fstrim.timer](https://github.com/karelzak/util-linux/blob/master/sys-utils/fstrim.timer)). [Commit a39461d355c365ff15875a4d0ad27e73cf717c59](https://github.com/karelzak/util-linux/commit/a39461d355c365ff15875a4d0ad27e73cf717c59)


