### PR TITLE
Make explicit that being in the audio group is required for pipewire-pulse.

### DIFF
--- a/src/config/media/pipewire.md
+++ b/src/config/media/pipewire.md
@@ -69,4 +69,5 @@ on glibc-based systems:
 
 The Pulseaudio replacement requires the
 [`XDG_RUNTIME_DIR`](../session-management.html#xdg_runtime_dir) environment
-variable to work correctly.
+variable and the user being in the [`audio`](../users-and-groups.md) group to
+work correctly.


### PR DESCRIPTION
In addition to the `XDG_RUNTIME_DIR`, I've found that with a clean base install of voidlinux, if I follow the handbook to add audio support by choosing the pipewire-puse route, I need to also add my user to the `audio` group, otherwise, `pactl info` would show pipewire is being used and everything appears to be correct, but just no sound.