### PR TITLE
mirrors: Add mirror at FIT CTU in Prague, CZ

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -42,6 +42,7 @@ sub-repository.
 | <https://mirrors.dotsrc.org/voidlinux/>            | EU: Denmark       |
 | <https://quantum-mirror.hu/mirrors/pub/voidlinux/> | EU: Hungary       |
 | <https://voidlinux.qontinuum.space:4443/>          | EU: Monaco        |
+| <https://mirror.fit.cvut.cz/voidlinux/>            | EU: Prague, CZ    |
 | <http://ftp.debian.ru/mirrors/voidlinux/>          | EU: Russia        |
 | <https://mirror.yandex.ru/mirrors/voidlinux/>      | EU: Russia        |
 | <https://cdimage.debian.org/mirror/voidlinux/>     | EU: Sweden        |


### PR DESCRIPTION
Currently, we mirror all files except debug/ and packages for ancient architectures (i686, armv6l).