### PR TITLE
update mirror change instruction.md

### DIFF
--- a/src/xbps/repositories/mirrors/changing.md
+++ b/src/xbps/repositories/mirrors/changing.md
@@ -11,7 +11,7 @@ To modify mirror URLs cleanly, copy all the repository configuration files to
 ```
 # mkdir -p /etc/xbps.d
 # cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
-# sed -i 's|https://alpha.de.repo.voidlinux.org|<repository>|g' /etc/xbps.d/*-repository-*.conf
+# sed -i 's|<repository>|https://alpha.us.repo.voidlinux.org|g' /etc/xbps.d/*-repository-*.conf
 ```
 
 After changing the URLs, you must synchronize xbps with the new mirrors:


### PR DESCRIPTION
in the instructions of the documentation it appears that I must put this command:

```
# sed -i 's|https://alpha.de.repo.voidlinux.org|<repository>|g' /etc/xbps.d/*-repository-*.conf
```

but it doesn't work(doesn't add changes)

i asked in the telegram group and it turned out that it worked like this:

```
# sed -i 's|<repository>|https://alpha.de.repo.voidlinux.org|g' /etc/xbps.d/*-repository-*.conf
```

leaving the instructions like this:

```
1 # mkdir -p /etc/xbps.d
2 # cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
3 # sed -i 's|<repository>|https://alpha.de.repo.voidlinux.org|g' /etc/xbps.d/*-repository-*.conf
```

Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
