### PR TITLE
Add instruction for making the `run` file for per-user service executable

### DIFF
--- a/src/config/services/user-services.md
+++ b/src/config/services/user-services.md
@@ -8,7 +8,7 @@ create a system-level service that runs
 start and monitor the services in a personal services directory.
 
 For example, you could create a service called `/etc/sv/runsvdir-<username>`
-with the following `run` script:
+with the following `run` script, which should be executable:
 
 ```
 #!/bin/sh


### PR DESCRIPTION
It's a small thing but many newcomers after creating the `run` file in `/etc/sv/<username>-runsvdir` forget to make it executable. I think the reason is that to those unfamiliar with runit, it doesn't sink in that the service file are executable sh scripts rather than config files like systemd has.

I have seen multiple people facing this stumbling block both in IRC and on the subreddit so thought it's a small change that would be he helpful.

Currently I think the PR could be violating this guideline:

> Command code-blocks should not be used to describe routine tasks documented
elsewhere in this Handbook.

If this is the case feel free to let me know. I can change it to something like:

```diff
For example, you could create a service called `/etc/sv/runsvdir-<username>`
-with the following `run` script:
+with the following `run` script and make it executable:
```

Currently the check.sh script returned no errors.