### PR TITLE
media: add note about audio group.

### DIFF
--- a/src/config/media/index.md
+++ b/src/config/media/index.md
@@ -8,3 +8,6 @@ To setup audio on your Void Linux system you have to decide if you want to use
 
 Some applications require PulseAudio, especially closed source programs, but
 [PipeWire](./pipewire.md) provides a drop-in replacement for PulseAudio.
+
+If [elogind](../session-management.md) is not enabled, it is necessary to be in
+the `audio` group in order to have access to audio devices.


### PR DESCRIPTION
elogind will use posix attributes to give logged in users access to
devices tagged as uaccess (such as audio and joystick input devices).
Without it, it's necessary to be in the audio group to access them.

Closes #587

@st3r4g thoughts?

