### PR TITLE
ci: clean-up scripts.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,9 @@ on: pull_request
 jobs:
   only:
     name: Check formatting and links
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
-      image: ghcr.io/void-linux/void-linux:latest-full-x86_64-musl
+      image: ghcr.io/void-linux/void-linux:latest-mini-x86_64-musl
     steps:
       - name: Prepare container
         run: |

--- a/res/ci/check-summary.sh
+++ b/res/ci/check-summary.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 cd src/ || exit 2
 

--- a/res/ci/format.sh
+++ b/res/ci/format.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Fetch upstream
-git fetch git://github.com/void-linux/void-docs.git master
-
 echo "Checking links"
 RUST_LOG=linkcheck=debug mdbook-linkcheck -s
 LINKCHECK=$?


### PR DESCRIPTION
- use /bin/sh shebang for check-summary.  Works just fine and avoids
  pulling in bash for the CI run.
- don't fetch upstream repository, not necessary.
- use mini-bb-x86_64-musl image to speed up container setup.

Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
