### PR TITLE
network/index: clarify default use of dhcpcd on live images

### DIFF
--- a/src/config/network/index.md
+++ b/src/config/network/index.md
@@ -1,8 +1,10 @@
 # Network
 
-Network configuration in Void Linux can be done in several ways. The default
-installation comes with the [dhcpcd(8)](https://man.voidlinux.org/dhcpcd.8)
-service enabled.
+Network configuration in Void Linux can be done in several ways.
+
+When Void is installed from live images using the `void-installer` application,
+[dhcpcd(8)](https://man.voidlinux.org/dhcpcd.8) is used to configure networking
+and the settings are applied to the new system.
 
 ## Interface Names
 


### PR DESCRIPTION
closes #595

Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
