### PR TITLE
src/xbps/index.md: Mention `xpkg` to list installed packages

### DIFF
--- a/src/xbps/index.md
+++ b/src/xbps/index.md
@@ -120,7 +120,14 @@ This requires `xbps-query` to download parts of every package to find the file.
 `xlocate`, however, queries a locally cached index of all files, so no network
 access is required.
 
-To get a list of all installed packages, without their version:
+To get a list of all installed packages without their version, use `xpkg` from
+the `xtools` package:
+
+```
+$ xpkg
+```
+
+Alternatively, use:
 
 ```
 $ xbps-query -l | awk '{ print $2 }' | xargs -n1 xbps-uhelper getpkgname


### PR DESCRIPTION
Reasons for mentioning this:

- using `xpkg` is much simpler: one command without arguments vs. 3 commands piped together
- xpkg is much faster: 0.13 s versus 3.28 s (on a C2D laptop with SSD from 2011)
