### PR TITLE
Network install: Copy RSA keys from installation medium to target

### DIFF
--- a/src/installation/guides/chroot.md
+++ b/src/installation/guides/chroot.md
@@ -107,16 +107,19 @@ does not need to be the same. If your host is running an x86_64 operating
 system, any of the three architectures can be installed (whether the host is
 musl or glibc), but an i686 host can only install i686 distributions.
 
+Copy the RSA keys from the installation medium to the target root directory:
+
+```
+# mkdir -p /mnt/var/db/xbps/keys
+# cp /var/db/xbps/keys/* /mnt/var/db/xbps/keys/
+```
+
 Use [xbps-install(1)](https://man.voidlinux.org/xbps-install.1) to bootstrap the
 installation by installing the `base-system` metapackage:
 
 ```
 # XBPS_ARCH=$ARCH xbps-install -S -r /mnt -R "$REPO" base-system
 ```
-
-`xbps-install` might ask you to [verify the RSA
-keys](../../xbps/troubleshooting/common-issues.md#verifying-rsa-keys) for the
-packages you are installing.
 
 ### The ROOTFS Method
 

--- a/src/installation/guides/fde.md
+++ b/src/installation/guides/fde.md
@@ -129,22 +129,22 @@ On a UEFI system, the EFI system partition also needs to be mounted.
 # mount /dev/sda1 /mnt/boot/efi
 ```
 
+Copy the RSA keys from the installation medium to the target root directory:
+
+```
+# mkdir -p /mnt/var/db/xbps/keys
+# cp /var/db/xbps/keys/* /mnt/var/db/xbps/keys/
+```
+
 Before we enter the chroot to finish up configuration, we do the actual install.
 Do not forget to use the [appropriate repository
 URL](../../xbps/repositories/index.md#the-main-repository) for the type of
 system you wish to install.
 
-`xbps-install` might ask you to [verify the RSA
-keys](../../xbps/troubleshooting/common-issues.md#verifying-rsa-keys) for the
-packages you are installing.
-
 ```
 # xbps-install -Sy -R https://alpha.de.repo.voidlinux.org/current -r /mnt base-system lvm2 cryptsetup grub
 [*] Updating `https://alpha.de.repo.voidlinux.org/current/x86_64-repodata' ...
 x86_64-repodata: 1661KB [avg rate: 2257KB/s]
-`https://alpha.de.repo.voidlinux.org/current' repository has been RSA signed by "Void Linux"
-Fingerprint: 60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d
-Do you want to import this public key? [Y/n] y
 130 packages will be downloaded:
 ...
 ```

--- a/src/xbps/troubleshooting/common-issues.md
+++ b/src/xbps/troubleshooting/common-issues.md
@@ -2,14 +2,17 @@
 
 ## Verifying RSA keys
 
-If you are installing Void for the first time or the Void RSA key has changed,
-[xbps-install(1)](https://man.voidlinux.org/xbps-install.1) might report:
+If the Void RSA key has changed,
+[xbps-install(1)](https://man.voidlinux.org/xbps-install.1) will report the new
+key fingerprint and ask you to confirm it:
 
 ```
-<repository> repository has been RSA signed by <rsa_fingerprint>
+<repository> repository has been RSA signed by "Void Linux"
+Fingerprint: <rsa_fingerprint>
+Do you want to import this public key? [Y/n]
 ```
 
-To verify the signature, ensure the `<rsa_fingerprint>` matches one of the
+To verify the key, ensure the `<rsa_fingerprint>` matches one of the
 fingerprints in both
 [void-packages](https://github.com/void-linux/void-packages/tree/master/common/repo-keys)
 and [void-mklive](https://github.com/void-linux/void-mklive/tree/master/keys).


### PR DESCRIPTION
This removes confusing warnings that "xbps might ask you to verify the
RSA keys", and eases the installation process for the user, since no
key fingerprints have to be compared manually.

Closes https://github.com/void-linux/void-docs/issues/645