### PR TITLE
index.md: Added missed / to https://voidlinux.mirror.garr.it

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -40,7 +40,7 @@ sub-repository.
 | <http://ftp.dk.xemacs.org/voidlinux/>              | EU: Denmark       |
 | <https://mirrors.dotsrc.org/voidlinux/>            | EU: Denmark       |
 | <https://quantum-mirror.hu/mirrors/pub/voidlinux/> | EU: Hungary       |
-| <https://voidlinux.mirror.garr.it>                 | EU: Italy         |
+| <https://voidlinux.mirror.garr.it/>                | EU: Italy         |
 | <https://mirror.fit.cvut.cz/voidlinux/>            | EU: Prague, CZ    |
 | <http://ftp.debian.ru/mirrors/voidlinux/>          | EU: Russia        |
 | <https://mirror.yandex.ru/mirrors/voidlinux/>      | EU: Russia        |


### PR DESCRIPTION
I am creating auto choose mirror script and this little bothered me so...
