### PR TITLE
Specify Parition Type

### DIFF
--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -102,6 +102,9 @@ If using BIOS, it is recommended you select MBR for the partition table.
 Advanced users may use GPT but will need to [create a special BIOS
 partition](./partitions.md#bios-system-notes) for GRUB to boot.
 
+The root file system will need a partition of type `Linux filesystem` which will
+be mounted at `/`.
+
 See the [Partitioning Notes](./partitions.md) for more details about
 partitioning your disk.
 


### PR DESCRIPTION
This PR just appends some text to the partitioning instructions to clarify what type of partition to create out of the massive list of partition types.