### PR TITLE
installation/live-images/index.md: remove references to flavour images

### DIFF
--- a/src/installation/live-images/index.md
+++ b/src/installation/live-images/index.md
@@ -24,32 +24,24 @@ The base images provide only a minimal set of packages to install a usable Void
 system. These base packages are only those needed to configure a new machine,
 update the system, and install additional packages from repositories.
 
-### Flavor images
+### Xfce image
 
-Each of the Void "flavor" images includes a full desktop environment, web
-browser, and basic applications configured for that environment. The only
-difference from the base images is the additional packages and services
-installed.
+The xfce image includes a full desktop environment, web browser, and basic
+applications configured for that environment. The only difference from the base
+images is the additional packages and services installed.
 
-The install process for each of the flavor images is the same as the base
-images, except that you **must** select the `Local` source when installing. If
-you select `Network` instead, the installer will download and install the latest
-version of the base system, without any additional packages included on the live
-image.
+The following software is included:
 
-#### Comparison of flavor images
+- **Window manager:** xfwm4
+- **File manager:** Thunar
+- **Web Browser:** Firefox ESR
+- **Terminal:** xfce4-terminal
+- **Plain text editor:** Mousepadd
+- **Image viewer:** Ristretto
+- **Other:** Bulk rename, Orage Globaltime, Orage Calendar, Task Manager, Parole
+   Media Player, Audio Mixer, MIME type editor, Application finder
 
-Here's a quick overview of the main components and applications included with
-each flavor:
-
-|                   | Enlightenment                                         | Cinnamon        | LXDE                                    | LXQT           | MATE                                                                                                                                                                | XFCE                                                                                                                                |
-|-------------------|-------------------------------------------------------|-----------------|-----------------------------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| Window Manager    | Enlightenment Window Manager                          | Mutter (Muffin) | Openbox                                 | Openbox        | Metacity (Marco)                                                                                                                                                    | xfwm4                                                                                                                               |
-| File Manager      | Enlightenment File Manager                            | Nemo            | PCManFM                                 | PCManFM-Qt     | Caja                                                                                                                                                                | Thunar                                                                                                                              |
-| Web Browser       | Firefox ESR                                           | Firefox ESR     | Firefox ESR                             | QupZilla       | Firefox ESR                                                                                                                                                         | Firefox ESR                                                                                                                         |
-| Terminal          | Terminology                                           | gnome-terminal  | LXTerminal                              | QTerminal      | MATE terminal                                                                                                                                                       | xfce4-Terminal                                                                                                                      |
-| Document Viewer   | -                                                     | -               | -                                       | -              | Atril (PS/PDF)                                                                                                                                                      | -                                                                                                                                   |
-| Plain text viewer | -                                                     | -               | -                                       | -              | Pluma                                                                                                                                                               | Mousepad                                                                                                                            |
-| Image viewer      | -                                                     | -               | GPicView                                | LXImage        | Eye of MATE                                                                                                                                                         | Ristretto                                                                                                                           |
-| Archive unpacker  | -                                                     | -               | -                                       | -              | Engrampa                                                                                                                                                            | -                                                                                                                                   |
-| Other             | Mixer, EConnMan (connection manager), Elementary Test | -               | LXTask (task manager), MIME type editor | Screen grabber | Screen grabber, file finder, MATE color picker, MATE font viewer, Disk usage analyzer, Power statistics, System monitor (task manager), Dictionary, Log file viewer | Bulk rename, Orage Globaltime, Orage Calendar, Task Manager, Parole Media Player, Audio Mixer, MIME type editor, Application finder |
+The install process for the xfce image is the same as the base images, except
+that you **must** select the `Local` source when installing. If you select
+`Network` instead, the installer will download and install the latest version of
+the base system, without any additional packages included on the live image.


### PR DESCRIPTION
The table that compares all the flavour images is a bit misleading now that there is only the xfce image
