### PR TITLE
src/config/bluetooth.md: mention pipewire requirements

### DIFF
--- a/src/config/bluetooth.md
+++ b/src/config/bluetooth.md
@@ -23,7 +23,8 @@ processes making use of it.
 
 To use an audio device such as a wireless speaker or headset, ALSA users need to
 install the `bluez-alsa` package. [PulseAudio](./media/pulseaudio.md) users do
-not need any additional software.
+not need any additional software. [PipeWire](./media/pipewire.md) users need
+`libspa-bluetooth`.
 
 ## Usage
 


### PR DESCRIPTION
The bluetooth page does currently not mention the required packages for pipewire. I know that the pipewire page does state that `libspa-bluetooth` is required, but I had initially missed that and I feel like its a good idea to mention them on the bluetooth page as well.