### PR TITLE
Update session-management.md

### DIFF
--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -41,6 +41,14 @@ There is an alternative D-Bus configuration which takes advantage of elogind for
 features such as seat detection. It requires installing the `dbus-elogind`,
 `dbus-elogind-libs` and `dbus-elogind-x11` packages.
 
+If you will use Sway, you should have installed these packages in your system to work perfectly:
+- `elogind`
+- `polkitd-elogind`
+- `dbus-elogind-libs`
+- `dbus-elogind-x11`
+- `dbus-elogind`
+
+
 ## seatd
 
 [seatd(1)](https://man.voidlinux.org/seatd.1) is a minimal seat management


### PR DESCRIPTION
That avoids this issue:
```
disable-paste: cannot open mouse connection
00:00:00.006 [ERROR] [wlr] [libseat] [libseat/backend/logind.c:310] Could not activate session: Permission denied
00:00:00.006 [ERROR] [wlr] [libseat] [libseat/libseat.c:79] No backend was able to open a seat
00:00:00.006 [ERROR] [wlr] [backend/session/session.c:84] Unable to create seat: Function not implemented
00:00:00.006 [ERROR] [wlr] [backend/session/session.c:249] Failed to load session backend
00:00:00.006 [ERROR] [wlr] [backend/backend.c:86] Failed to start a session
00:00:00.006 [ERROR] [wlr] [backend/backend.c:352] Failed to start a DRM session
00:00:00.007 [ERROR] [sway/server.c:56] Unable to create backend
```

SRC: https://www.reddit.com/r/voidlinux/comments/mor7n5/getting_libseat_errors_when_starting_sway/

Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
