### PR TITLE
res/void-docs: add evince to fallback pdf viewers

### DIFF
--- a/res/void-docs.in
+++ b/res/void-docs.in
@@ -63,7 +63,7 @@ if [ "$_pdf" ]; then
     elif command -v run-mailcap >/dev/null; then
         exec run-mailcap --action=view $PDF
     else
-        for cmd in zathura okular
+        for cmd in zathura okular evince
         do
             if command -v $cmd >/dev/null; then
                 exec $cmd $PDF


### PR DESCRIPTION
evince is installed on the GNOME isos, but xdg-open isn't, so
void-docs -p fails.

cc @ericonr