### PR TITLE
.github/workflows/ci.yaml: fix CI failure if xbps needs update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Prepare container
         run: |
-          xbps-install -Syu || xbps-install -yu xbps
+          xbps-install -Syu || xbps-install -Syu xbps
           xbps-install -yu
           xbps-install -y mdbook-linkcheck vmdfmt git
       - uses: actions/checkout@v1


### PR DESCRIPTION
if the first `xbps-install` fails, then no repo index is kept, causing the last `xbps-install` to fail with `Package 'mdbook-linkcheck' not found in repository pool.`

