### PR TITLE
Update default mirror URL in sed command

### DIFF
--- a/src/xbps/repositories/mirrors/changing.md
+++ b/src/xbps/repositories/mirrors/changing.md
@@ -11,7 +11,7 @@ To modify mirror URLs cleanly, copy all the repository configuration files to
 ```
 # mkdir -p /etc/xbps.d
 # cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
-# sed -i 's|https://alpha.de.repo.voidlinux.org|<repository>|g' /etc/xbps.d/*-repository-*.conf
+# sed -i 's|https://repo-default.voidlinux.org|<repository>|g' /etc/xbps.d/*-repository-*.conf
 ```
 
 After changing the URLs, you must synchronize xbps with the new mirrors:
@@ -26,11 +26,11 @@ synchronized:
 
 ```
 $ xbps-query -L
- 9970 https://alpha.de.repo.voidlinux.org/current (RSA signed)
-   27 https://alpha.de.repo.voidlinux.org/current/multilib/nonfree (RSA signed)
- 4230 https://alpha.de.repo.voidlinux.org/current/multilib (RSA signed)
-   47 https://alpha.de.repo.voidlinux.org/current/nonfree (RSA signed)
- 5368 https://alpha.de.repo.voidlinux.org/current/debug (RSA signed)
+ 9970 https://repo-default.voidlinux.org/current (RSA signed)
+   27 https://repo-default.voidlinux.org/current/multilib/nonfree (RSA signed)
+ 4230 https://repo-default.voidlinux.org/current/multilib (RSA signed)
+   47 https://repo-default.voidlinux.org/current/nonfree (RSA signed)
+ 5368 https://repo-default.voidlinux.org/current/debug (RSA signed)
 ```
 
 Remember that repositories added afterwards will also need to be changed, or


### PR DESCRIPTION
While changing my mirrors, I noticed that the sed command replaces a URL (`https://alpha.de.repo.voidlinux.org`) different than the one present on my system (`https://repo-default.voidlinux.org`). This PR updates the command.