### PR TITLE
ci: fix summary check, make prints consistent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,6 @@ jobs:
         run: |
           xbps-install -Syu || xbps-install -Syu xbps
           xbps-install -yu
-          xbps-install -y mdbook-linkcheck vmdfmt git
+          xbps-install -y mdbook-linkcheck vmdfmt git findutils
       - uses: actions/checkout@v1
       - run: ./res/ci/format.sh

--- a/res/ci/check-summary.sh
+++ b/res/ci/check-summary.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+ERROR=0
+
 cd src/ || exit 2
 
 # summary is the list of files taken from SUMMARY.md - unused for now
@@ -9,11 +11,10 @@ files="$( find . -type f -name '*.md' -not -name "SUMMARY.md" )"
 
 for file in $files
 do
-    if ! grep "$file" ./SUMMARY.md >/dev/null 2>&1 ; then
-        echo "$file not in SUMMARY"
+    if ! grep "$file" ./SUMMARY.md >/dev/null ; then
+        printf "\033[31;1m=> $file not in SUMMARY\033[m\n"
         ERROR=1
     fi
 done
 
-[ -z "$ERROR" ] && exit 0
-exit 2
+exit $ERROR

--- a/res/ci/format.sh
+++ b/res/ci/format.sh
@@ -2,25 +2,24 @@
 
 git config --global --add safe.directory "$PWD"
 
-echo "Checking links"
+printf "\033[37;1m=> Checking links\033[m\n"
 RUST_LOG=linkcheck=debug mdbook-linkcheck -s
 LINKCHECK=$?
 
 # Format them
-printf "Formatting tree"
+printf "\n\033[37;1m=> Formatting tree\033[m\n"
 vmdfmt -l -w src/
 
 # Check Status
 if [ ! -z "$(git status --porcelain)" ] ; then
     git diff
-    echo "Working directory not clean, files to be formatted:"
+    printf "\033[31;1m=> Working directory not clean, files to be formatted:\033[m\n"
     git status
     VMDFMT=1
 fi
 
 # Check SUMMARY.md
-echo ""
-echo "Checking SUMMARY.md"
+printf "\n\033[37;1m=> Checking SUMMARY.md\033[m\n"
 res/ci/check-summary.sh
 SUMMARY=$?
 


### PR DESCRIPTION
without findutils, the summary check fails: `res/ci/check-summary.sh: 8: find: not found`