### PR TITLE
gnupg: add documentation about smartcard setups

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -67,6 +67,7 @@
    - [Containers and Virtual Machines](./config/containers-and-vms/index.md)
       - [libvirt](./config/containers-and-vms/libvirt.md)
       - [LXC](./config/containers-and-vms/lxc.md)
+   - [GnuPG](./config/gnupg.md)
 - [XBPS Package Manager](./xbps/index.md)
    - [Advanced Usage](./xbps/advanced-usage.md)
    - [Repositories](./xbps/repositories/index.md)

--- a/src/config/gnupg.md
+++ b/src/config/gnupg.md
@@ -1,0 +1,25 @@
+# GnuPG
+
+Void ships both GnuPG legacy (as `gnupg1`) and GnuPG stable (as `gnupg`).
+
+## Smartcards
+
+For using smartcards such as Yubikeys with GnuPG, there are two backends for
+communicating with them through GnuPG: The internal CCID driver of GnuPG's
+scdaemon, or the PC/SC driver.
+
+## scdaemon with internal CCID driver
+
+By default, scdaemon, which is required for using smartcards with GnuPG, uses
+its internal CCID driver. For this to work, your smartcard needs to be one of
+the smartcards in the udev rules
+[here](https://github.com/void-linux/void-packages/blob/master/srcpkgs/gnupg/files/60-scdaemon.rules)
+and you need to either be using elogind or be a member of the plugdev group. If
+these two condition are fulfilled and you don't have pcscd running, `gpg
+--card-status` should successfully print your current card status.
+
+## scdaemon with pcscd backend
+
+If you need to use pcscd for other reasons, run `echo disable-ccid >>
+~/.gnupg/scdaemon.conf`. Now, assuming your pcscd setup works correctly, `gpg
+--card-status` should print your card status.


### PR DESCRIPTION
The resulting page here is going to be linked in the `gnupg2-scdaemon.INSTALL.msg` which will resolve https://github.com/void-linux/void-packages/issues/38034, together with https://github.com/void-linux/void-packages/pull/38037.
