### PR TITLE
user-service: parametrize $USER using dir name

### DIFF
--- a/src/config/services/user-services.md
+++ b/src/config/services/user-services.md
@@ -13,8 +13,8 @@ with the following `run` script, which should be executable:
 ```
 #!/bin/sh
 
-export USER="<username>"
-export HOME="/home/<username>"
+export USER="${PWD#*-}"
+export HOME="/home/$USER"
 
 groups="$(id -Gn "$USER" | tr ' ' ':')"
 svdir="$HOME/service"
@@ -28,7 +28,8 @@ user. [chpst(8)](https://man.voidlinux.org/chpst.8) does not read groups on its
 own, but expects the user to list all required groups separated by a `:`. The
 `id` and `tr` pipe is used to create a list of all the user's groups in a way
 [chpst(8)](https://man.voidlinux.org/chpst.8) understands it. Note that we
-export `$USER` and `$HOME` because some user services may not work without them.
+export `$USER` and `$HOME` because some user services may not work without them,
+so we derive these from the service name (`/etc/sv/runsvdir-<username>`).
 
 The user can then create new services or symlinks to them in the
 `/home/<username>/service` directory. To control the services using the


### PR DESCRIPTION
I took a page from agetty's book:

```
~ ❯ cat /etc/sv/runsvdir-ag/run
#!/bin/sh

export USER="${PWD##*-}"
export HOME="/home/$USER"

groups="$(id -Gn "$USER" | tr ' ' ':')"
svdir="$HOME/.sv"

exec chpst -u "$USER:$groups" runsvdir "$svdir"
~ ❯ pgrep -af "runsvdir-$USER"
15673 runsv runsvdir-ag
```
<details>
<summary>Less interesting</summary>

```
~ ❯ ls -lR .sv
.sv:
total 4
drwxr-xr-x 3 ag users 4096 Aug 11 17:06 uhhhh

.sv/uhhhh:
total 8
-rwxr--r-- 1 ag users   36 Aug 11 17:05 run
drwx------ 2 ag users 4096 Aug 11 17:09 supervise

.sv/uhhhh/supervise:
total 12
prw------- 1 ag users  0 Aug 11 17:06 control
-rw------- 1 ag users  0 Aug 11 17:06 lock
prw------- 1 ag users  0 Aug 11 17:06 ok
-rw-r--r-- 1 ag users  6 Aug 11 17:09 pid
-rw-r--r-- 1 ag users  4 Aug 11 17:09 stat
-rw-r--r-- 1 ag users 20 Aug 11 17:09 status
~ ❯ cat .sv/uhhhh/run
#!/bin/sh

echo "uhhhh" && sleep 60
```
</details>
