### PR TITLE
book.toml: fix regexes, add flaky mirror to linkcheck exclude

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -21,4 +21,4 @@ optional = true
 [output.linkcheck]
 optional = true
 follow-web-links = true
-exclude = [ "kernel.org", "ntp.org", "\\.onion", "localhost", "sjtu.edu.cn", "userbase.kde.org" ]
+exclude = [ 'kernel\.org', 'ntp\.org', '\.onion', 'localhost', 'sjtu\.edu\.cn', 'userbase\.kde\.org', 'mirrors\.cnnic\.cn' ]


### PR DESCRIPTION
the exclude field is a list of regexes, so most of those links could match other urls.
Also switched to using toml raw strings.

https://michael-f-bryan.github.io/mdbook-linkcheck/mdbook_linkcheck/struct.Config.html#structfield.exclude
