### PR TITLE
guides/fde: Clarify GRUB LUKS2 support

### DIFF
--- a/src/installation/guides/fde.md
+++ b/src/installation/guides/fde.md
@@ -46,8 +46,15 @@ Device      Start       End   Sectors  Size Type
 ## Encrypted volume configuration
 
 [Cryptsetup](https://man.voidlinux.org/cryptsetup.8) defaults to LUKS2, yet GRUB
-releases before 2.06 only had support for LUKS1. Therefore, it might make sense
-to force LUKS1 if you wish to achieve better compatibility.
+releases before 2.06 only had support for LUKS1.
+
+LUKS2 is only partially supported by GRUB; specifically, only the PBKDF2 key
+derivation function is
+[implemented](https://git.savannah.gnu.org/cgit/grub.git/commit/?id=365e0cc3e7e44151c14dd29514c2f870b49f9755),
+which is *not* the default KDF used with LUKS2, that being Argon2i ([GRUB Bug
+59409](https://savannah.gnu.org/bugs/?59409)). LUKS encrypted partitions using
+Argon2i (as well as the other KDF) can *not* be decrypted. For that reason, this
+guide only recommends LUKS1 be used.
 
 Keep in mind the encrypted volume will be `/dev/sda2` on EFI systems, since
 `/dev/sda1` is taken up by the EFI partition.


### PR DESCRIPTION
GRUB only fully supports LUKS1 but also supports LUKS2's PBKDF2 function, which has not been clarified in the documentation before. This patch clarifies that the standard key derivation function, being Argon2i, is not supported by GRUB, avoiding confusion from potential other sources.

Closes: https://github.com/void-linux/void-docs/issues/620