### PR TITLE
installation/guides/fde: clarify glibc-only commands

### DIFF
--- a/src/installation/guides/fde.md
+++ b/src/installation/guides/fde.md
@@ -164,6 +164,11 @@ When it's done, we can enter the `chroot` and finish up the configuration.
 # chmod 755 /
 # passwd root
 # echo voidvm > /etc/hostname
+```
+
+and, for glibc systems only:
+
+```
 # echo "LANG=en_US.UTF-8" > /etc/locale.conf
 # echo "en_US.UTF-8 UTF-8" >> /etc/default/libc-locales
 # xbps-reconfigure -f glibc-locales


### PR DESCRIPTION
a user was confused by this: https://old.reddit.com/r/voidlinux/comments/xga33g/xbpsreconfigure_f_glibclocales_not_working/
