### PR TITLE
fde.md overhaul

### DIFF
--- a/src/installation/guides/fde.md
+++ b/src/installation/guides/fde.md
@@ -1,19 +1,18 @@
 # Full Disk Encryption
 
-**Warning**: Your drive's block device and other information may be different,
-so make sure it is correct.
+**Warning**: This guide uses `/dev/vda` as the example device name, Your drive's block device and other information may be different, so make sure it is correct.
 
 ## Partitioning
 
 Boot a live image and login.
 
-Create a single physical partition on the disk using
-[cfdisk](https://man.voidlinux.org/cfdisk), marking it as bootable. For an MBR
-system, the partition layout should look like the following.
+For a BIOS/MBR system, Create a single physical partition on the disk using
+[cfdisk](https://man.voidlinux.org/cfdisk) with a `dos` label type, Mark it as bootable.  
+Now the partition layout should look similar to the following.
 
 ```
-# fdisk -l /dev/sda
-Disk /dev/sda: 48 GiB, 51539607552 bytes, 100663296 sectors
+# fdisk -l /dev/vda
+Disk /dev/vda: 48 GiB, 51539607552 bytes, 100663296 sectors
 Units: sectors of 1 * 512 = 512 bytes
 Sector size (logical/physical): 512 bytes / 512 bytes
 I/O size (minimum/optimal): 512 bytes / 512 bytes
@@ -21,17 +20,17 @@ Disklabel type: dos
 Disk identifier: 0x4d532059
 
 Device     Boot Start       End   Sectors Size Id Type
-/dev/sda1  *     2048 100663295 100661248  48G 83 Linux
+/dev/vda1  *     2048 100663295 100661248  48G 83 Linux
 ```
 
 UEFI systems will need the disk to have a GPT disklabel and an EFI system
 partition. The required size for this may vary depending on needs, but 100M
 should be enough for most cases. For an EFI system, the partition layout should
-look like the following.
+look similar to the following.
 
 ```
-# fdisk -l /dev/sda
-Disk /dev/sda: 48 GiB, 51539607552 bytes, 100663296 sectors
+# fdisk -l /dev/vda
+Disk /dev/vda: 48 GiB, 51539607552 bytes, 100663296 sectors
 Units: sectors of 1 * 512 = 512 bytes
 Sector size (logical/physical): 512 bytes / 512 bytes
 I/O size (minimum/optimal): 512 bytes / 512 bytes
@@ -39,94 +38,94 @@ Disklabel type: gpt
 Disk identifier: EE4F2A1A-8E7F-48CA-B3D0-BD7A01F6D8A0
 
 Device      Start       End   Sectors  Size Type
-/dev/sda1    2048    264191    262144  128M EFI System
-/dev/sda2  264192 100663262 100399071 47.9G Linux filesystem
+/dev/vda1    2048    264191    262144  128M EFI System
+/dev/vda2  264192 100663262 100399071 47.9G Linux filesystem
 ```
 
 ## Encrypted volume configuration
 
-[Cryptsetup](https://man.voidlinux.org/cryptsetup.8) defaults to LUKS2, yet GRUB
-releases before 2.06 only had support for LUKS1. Therefore, it might make sense
-to force LUKS1 if you wish to achieve better compatibility.
+[Cryptsetup](https://man.voidlinux.org/cryptsetup.8) defaults to LUKS2, GRUB 
+2.06 introduced support for LUKS2, but did not add support for the LUKS2 default 
+cryptographic algorithm, [Argon2i](https://en.wikipedia.org/wiki/Argon2). 
+Therefore, for compatibility reasons it might make sense to use LUKS1 until GRUB 
+receives support for Argon2i.
 
-Keep in mind the encrypted volume will be `/dev/sda2` on EFI systems, since
-`/dev/sda1` is taken up by the EFI partition.
+**Warning**: If the password for the encrypted partition is lost it will become near (or completely) impossible to recover any data or the password
 
-```
-# cryptsetup luksFormat --type luks1 /dev/sda1
-
-WARNING!
-========
-This will overwrite data on /dev/sda1 irrevocably.
-
-Are you sure? (Type uppercase yes): YES
-Enter passphrase:
-Verify passphrase:
-```
-
-Once the volume is created, it needs to be opened. Replace `voidvm` with an
-appropriate name. Again, this will be `/dev/sda2` on EFI systems.
+On legacy BIOS systems this command would use `/dev/vda1`.
 
 ```
-# cryptsetup luksOpen /dev/sda1 voidvm
-Enter passphrase for /dev/sda1:
+# cryptsetup luksFormat --type luks1 /dev/vda2
 ```
 
-Once the LUKS container is opened, create the LVM volume group using that
-partition.
+Once the volume is created, it needs to be opened. `voidvm` is a example name
+you can replace it with a name of your choosing. Again, this will be `/dev/vda1` on legacy BIOS systems.
+
+```
+# cryptsetup open /dev/vda2 voidvm
+```
+
+### LVM
+
+Once the LUKS partition is opened you can create a [LVM](https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)) volume group using that
+partition. 
+LVM is optional and may have its advantages or disadvantages depending on your system configuration.
+
+The volume group name is not required to be the same as the LUKS partition name chosen above, 
+But for consistency purposes it may be easier to use the same name for the volume group.
 
 ```
 # vgcreate voidvm /dev/mapper/voidvm
-  Volume group "voidvm" successfully created
 ```
 
 There should now be an empty volume group named `voidvm`.
 
-Next, logical volumes need to be created for the volume group. For this example,
-I chose 10G for `/`, 2G for `swap`, and will assign the rest to `/home`.
+Next, logical volumes need to be created for the volume group. 
+For this example, All of the available space is assigned to `/`.
+
+The name chosen using `--name` should be noted because it will be used when mounting the partition, For example, `/dev/voidvm/root`.
 
 ```
-# lvcreate --name root -L 10G voidvm
-  Logical volume "root" created.
-# lvcreate --name swap -L 2G voidvm
-  Logical volume "swap" created.
-# lvcreate --name home -l 100%FREE voidvm
-  Logical volume "home" created.
+# lvcreate --name root -l 100%FREE voidvm
 ```
 
-Next, create the filesystems. The example below uses XFS as a personal
-preference of the author. Any filesystem [supported by
+### Filesystem creation
+
+Next, create the filesystems. The example below uses Btrfs. Any filesystem [supported by
 GRUB](https://www.gnu.org/software/grub/manual/grub/grub.html#Features) will
 work.
 
+On systems using LVM the root filesystem would be created on `/dev/voidvm/root`.
+
 ```
-# mkfs.xfs -L root /dev/voidvm/root
-meta-data=/dev/voidvm/root       isize=512    agcount=4, agsize=655360 blks
-...
-# mkfs.xfs -L home /dev/voidvm/home
-meta-data=/dev/voidvm/home       isize=512    agcount=4, agsize=2359040 blks
-...
-# mkswap /dev/voidvm/swap
-Setting up swapspace version 1, size = 2 GiB (2147479552 bytes)
+# mkfs.btrfs /dev/mapper/voidvm
+```
+
+On UEFI systems the EFI partition also needs the filesystem created.
+
+```
+# mkfs.vfat -F32 /dev/vda1
 ```
 
 ## System installation
 
-Next, setup the chroot and install the base system.
+Next, mount the root partition, On a LVM configuration this would be `/dev/voidvm/root`
 
 ```
-# mount /dev/voidvm/root /mnt
+# mount /dev/mapper/voidvm /mnt
+```
+
+Next, some extra directories need to be mounted.
+
+```
 # for dir in dev proc sys run; do mkdir -p /mnt/$dir ; mount --rbind /$dir /mnt/$dir ; mount --make-rslave /mnt/$dir ; done
-# mkdir -p /mnt/home
-# mount /dev/voidvm/home /mnt/home
 ```
 
-On a UEFI system, the EFI system partition also needs to be mounted.
+On a UEFI system, the `/efi` directory needs to be created and EFI system partition needs to be mounted.
 
 ```
-# mkfs.vfat /dev/sda1
-# mkdir -p /mnt/boot/efi
-# mount /dev/sda1 /mnt/boot/efi
+# mkdir /mnt/efi
+# mount /dev/vda1 /mnt/efi
 ```
 
 Copy the RSA keys from the installation medium to the target root directory:
@@ -136,34 +135,28 @@ Copy the RSA keys from the installation medium to the target root directory:
 # cp /var/db/xbps/keys/* /mnt/var/db/xbps/keys/
 ```
 
-Before we enter the chroot to finish up configuration, we do the actual install.
-Do not forget to use the [appropriate repository
-URL](../../xbps/repositories/index.md#the-main-repository) for the type of
-system you wish to install.
+Before entering the chroot to finish up configuration, it is time to perform the actual install.
+Do not forget to use the [appropriate repository URL](../../xbps/repositories/index.md#the-main-repository) 
+for the type of system you wish to install.
+
+Legacy BIOS systems use the `grub` package instead of `grub-x86_64-efi`. For LVM users, The `lvm2` package is required.
 
 ```
-# xbps-install -Sy -R https://repo-default.voidlinux.org/current -r /mnt base-system lvm2 cryptsetup grub
-[*] Updating `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
-x86_64-repodata: 1661KB [avg rate: 2257KB/s]
-130 packages will be downloaded:
-...
+# xbps-install -Sy -R https://repo-default.voidlinux.org/current -r /mnt base-system cryptsetup grub-x86_64-efi
 ```
 
-UEFI systems will have a slightly different package selection. The installation
-command for a UEFI system will be as follows.
+Before entering the chroot, Copy a DNS configuration file from live system to allow internet connection in the chroot.
 
 ```
-# xbps-install -Sy -R https://repo-default.voidlinux.org/current -r /mnt base-system cryptsetup grub-x86_64-efi lvm2
+# cp /etc/resolv.conf /mnt/etc/
 ```
 
-When it's done, we can enter the `chroot` and finish up the configuration.
+Now you can enter the [chroot(1)](https://man.voidlinux.org/chroot.1) and continue configuring the system.
 
 ```
 # chroot /mnt
-# chown root:root /
-# chmod 755 /
 # passwd root
-# echo voidvm > /etc/hostname
+# echo AHOSTNAME > /etc/hostname
 ```
 
 and, for glibc systems only:
@@ -176,44 +169,51 @@ and, for glibc systems only:
 
 ### Filesystem configuration
 
-The next step is editing `/etc/fstab`, which will depend on how you configured
-and named your filesystems. For this example, the file should look like this:
+Before continuing with filesystem configuration you need to get your [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)s,
+This can be done using utilities such as: [lsblk(8)](https://man.voidlinux.org/lsblk.8) or [blkid(8)](https://man.voidlinux.org/blkid.8).
+
+The next step is editing `/etc/fstab`, 
+The UUID needed for `/etc/fstab` is the `/dev/mapper/voidvm` UUID on non-LVM configurations and `/dev/voidvm/root` UUID on LVM configurations
+
+```
+# blkid -o value -s UUID /dev/mapper/voidvm
+```
 
 ```
 # <file system>	   <dir> <type>  <options>             <dump>  <pass>
 tmpfs             /tmp  tmpfs   defaults,nosuid,nodev 0       0
-/dev/voidvm/root  /     xfs     defaults              0       0
-/dev/voidvm/home  /home xfs     defaults              0       0
-/dev/voidvm/swap  swap  swap    defaults              0       0
+UUID=ADD-UUID-FROM-BLKID-COMMAND-HERE   /     btrfs   defaults              0       0
 ```
+
 
 UEFI systems will also have an entry for the EFI system partition.
 
 ```
-/dev/sda1	/boot/efi	vfat	defaults	0	0
+# blkid -o value -s UUID /dev/vda1
+```
+
+```
+UUID=ADD-UUID-FROM-BLKID-COMMAND-HERE	/efi	vfat	defaults	0	0
 ```
 
 ### GRUB configuration
 
-Next, configure GRUB to be able to unlock the filesystem. Add the following line
-to `/etc/default/grub`:
+Next, configure GRUB to be able to unlock the encrypted filesystem:
 
 ```
-GRUB_ENABLE_CRYPTODISK=y
+# echo "GRUB_ENABLE_CRYPTODISK=y" >> /etc/default/grub
 ```
 
 Next, the kernel needs to be configured to find the encrypted device. First,
-find the UUID of the device.
+get the UUID of the device, Again this would be `/dev/vda1` on legacy BIOS systems.
 
 ```
-# blkid -o value -s UUID /dev/sda1
-135f3c06-26a0-437f-a05e-287b036440a4
+# blkid -o value -s UUID /dev/vda2
 ```
 
-Edit the `GRUB_CMDLINE_LINUX_DEFAULT=` line in `/etc/default/grub` and add
-`rd.lvm.vg=voidvm rd.luks.uuid=<UUID>` to it. Make sure the UUID matches the one
-for the `sda1` device found in the output of the
-[blkid(8)](https://man.voidlinux.org/blkid.8) command above.
+Next, Edit the `GRUB_CMDLINE_LINUX_DEFAULT=` line in `/etc/default/grub` and add
+`rd.luks.uuid=ADD-UUID-FROM-BLKID-COMMAND-HERE` to it, If you are on a LVM configuration
+also add `rd.lvm.vg=voidvm`.
 
 ## LUKS key setup
 
@@ -223,16 +223,12 @@ a random key.
 
 ```
 # dd bs=1 count=64 if=/dev/urandom of=/boot/volume.key
-64+0 records in
-64+0 records out
-64 bytes copied, 0.000662757 s, 96.6 kB/s
 ```
 
-Next, add the key to the encrypted volume.
+Next, add the key to the encrypted volume. Again, this would be `/dev/vda1` on legacy BIOS systems.
 
 ```
-# cryptsetup luksAddKey /dev/sda1 /boot/volume.key
-Enter any existing passphrase:
+# cryptsetup luksAddKey /dev/vda2 /boot/volume.key
 ```
 
 Change the permissions to protect generated the key.
@@ -242,11 +238,15 @@ Change the permissions to protect generated the key.
 # chmod -R g-rwx,o-rwx /boot
 ```
 
-This keyfile also needs to be added to `/etc/crypttab`. Again, this will be
-`/dev/sda2` on EFI systems.
+This keyfile also needs to be added to `/etc/crypttab`. Again, this would be
+`/dev/vda1` on legacy BIOS systems.
 
 ```
-voidvm   /dev/sda1   /boot/volume.key   luks
+# blkid -o value -s UUID /dev/vda2
+```
+
+```
+voidvm   UUID=ADD-UUID-FROM-BLKID-COMMAND-HERE   /boot/volume.key   luks
 ```
 
 And then the keyfile and `crypttab` need to be included in the initramfs. Create
@@ -260,8 +260,13 @@ install_items+=" /boot/volume.key /etc/crypttab "
 
 Next, install the boot loader to the disk.
 
+For legacy BIOS systems:
 ```
-# grub-install /dev/sda
+# grub-install --target=i386-pc /dev/vda
+```
+For UEFI systems:
+```
+# grub-install --target=x86_64-efi --efi-directory=/efi --bootloader-id="Void"
 ```
 
 Ensure an initramfs is generated:
@@ -270,10 +275,24 @@ Ensure an initramfs is generated:
 # xbps-reconfigure -fa
 ```
 
-Exit the `chroot`, unmount the filesystems, and reboot the system.
+Exit the `chroot`, unmount the filesystems. 
 
 ```
 # exit
 # umount -R /mnt
+```
+
+If you are using a LVM configuration you will need to run the following commands before continuing with the rest of the commands.
+
+```
+# lvchange -an voidvm
+
+# cryptsetup close /dev/voidvm/root
+```
+
+Finally, Close the encrypted partition and reboot the system.
+
+```
+# cryptsetup close /dev/mapper/voidvm
 # reboot
 ```


### PR DESCRIPTION
* Changed example device to /dev/vda and added note about /dev/vda being the example device in the Warning.

* Changed legacy BIOS Partitioning section from MBR system to BIOS/MBR system, Added using dos label type in cfdisk.

* Changed Encrypted volume configuration to include why LUKS1 is recommended instead of LUKS2 (GRUB lacks support for Argon2i).
~ Closes issue: #620 
~ Closes PRs: #705 and #621 

* Added Warning about recovering the password/data if the password for the encrypted partition is lost.

* Changed guide to default to UEFI systems with notes about legacy BIOS systems when needed.
~ Closes issues: #533 

* Noted that voidvm is a example name.

* Changed cryptsetup commands from luksOpen and luksClose to open and close.

* Made LVM a optional step, With notes about differences for LVM configurations when needed.

* Removed creation of a "home" logical volume.

* Removed swap information - Swap has many ways to be setup (file or partition, encrypted or unencrypted, with or without suspend-to-disk support, etc) and may be better suited as a separate page in void-docs.

* Added a note about the logical volume name chosen using --name, This name is used when mounting.

* Removed output from some commands.

* Changed example filesystem to Btrfs.

* Moved creation of the EFI partition (for UEFI system) below root filesystem creation.

* Removed creation of /mnt/home and mounting of /dev/voidvm/home, The creation of a home logical volume was removed.

* Separated command for mounting the root partition.

* Changed EFI partition mount point to /efi, This change makes /boot encrypted by default, Leaving only /efi unencrypted (as of writing a unencrypted EFI partition is required by UEFI).

* Changed base install to UEFI, With a note for switching grub-x86_64-efi to grub on legacy BIOS systems, LVM users are also noted to install the lvm2 package.

* Added command to copy a DNS configuration from the live system to allow a internet connection in the chroot.

* Removed changing permissions after chroot, This seemed uneeded in my testing.

* Changed example hostname from voidvm to AHOSTNAME to make it more apparent that the user should choose their own hostname.

* Added a section in Filesystem configuration about getting the required UUIDs, For every step that requires a UUID a blkid command is included to get the UUID.

* Changed /etc/fstab and /etc/crypttab to use UUID= instead of /dev/voidvm/root or /dev/sda1. 
~ Closes issues: #662 

* Changed GRUB_ENABLE_CRYPTODISK=y to echo "GRUB_ENABLE_CRYPTODISK=y" >> /etc/default/grub.

* Noted that rd.lvm.vg=voidvm for /etc/default/grub is for LVM configurations.

* Changed grub-install commands to be separate for legacy BIOS and UEFI, The legacy BIOS grub-install command now has --target=i386-pc.

* Changed cryptsetup close to include steps for LVM configurations.

* Wording and other General changes (also might have missed a few changes).
~ Might close issue?: #492 
~ Might close some tasks?: #327 and #85 
~ Might close PR?: #566 