### PR TITLE
installation/live-images/guide: improve wireless install guide

### DIFF
--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -39,9 +39,11 @@ use the "us" keymap.
 Select your primary network interface. If you do not choose to use DHCP, you
 will be prompted to provide an IP address, gateway, and DNS servers.
 
-If you intend to use a wireless connection during the installation, you may need
-to configure it manually using wpa_supplicant and dhcpcd manually before running
-`void-installer`.
+If you choose a wireless network interface, you will be prompted to provide the
+SSID, encryption type (`wpa` or `wep`), and password. If `void-installer` fails
+to connect to your network, you may need to exit the installer and configure it
+manually using [wpa_supplicant](../../config/network/wpa_supplicant.md) and
+[dhcpcd](../../config/network/index.md#dhcpcd) before continuing.
 
 ## Source
 


### PR DESCRIPTION
now that el-cheapo works with wpa_supplicant again, let's stop recommending to configure wifi manually.

