### PR TITLE
ftp.acc.umu.se moves to mirror.accum.se

### DIFF
--- a/src/xbps/repositories/mirrors/index.md
+++ b/src/xbps/repositories/mirrors/index.md
@@ -46,10 +46,8 @@ sub-repository.
 | <https://mirror.fit.cvut.cz/voidlinux/>            | EU: Prague, CZ    |
 | <http://ftp.debian.ru/mirrors/voidlinux/>          | EU: Russia        |
 | <https://mirror.yandex.ru/mirrors/voidlinux/>      | EU: Russia        |
-| <https://cdimage.debian.org/mirror/voidlinux/>     | EU: Sweden        |
-| <https://ftp.acc.umu.se/mirror/voidlinux/>         | EU: Sweden        |
+| <https://mirror.accum.se/mirror/voidlinux/>        | EU: Sweden        |
 | <https://ftp.lysator.liu.se/pub/voidlinux/>        | EU: Sweden        |
-| <https://ftp.sunet.se/mirror/voidlinux/>           | EU: Sweden        |
 | <https://void.sakamoto.pl/>                        | EU: Warsaw, PL    |
 | <https://mirror.vofr.net/voidlinux/>               | USA: California   |
 | <https://mirror2.sandyriver.net/pub/voidlinux/>    | USA: Kentucky     |


### PR DESCRIPTION
Background: Umeå University has decided that non-official services are no longer allowed to exist as a sub domain to umu.se. As a consequence of this we are moving all services from the acc.umu.se domain.

Additionally, this commit removes the duplicate entries cdimage.debian.org and ftp.sunet.se which are all served by our mirror.
