### PR TITLE
Remind reader to use correct device on EFI systems

### DIFF
--- a/src/installation/guides/fde.md
+++ b/src/installation/guides/fde.md
@@ -220,7 +220,8 @@ find the UUID of the device.
 Edit the `GRUB_CMDLINE_LINUX_DEFAULT=` line in `/etc/default/grub` and add
 `rd.lvm.vg=voidvm rd.luks.uuid=<UUID>` to it. Make sure the UUID matches the one
 for the `sda1` device found in the output of the
-[blkid(8)](https://man.voidlinux.org/blkid.8) command above.
+[blkid(8)](https://man.voidlinux.org/blkid.8) command above. This will be
+`/dev/sda2` on EFI systems.
 
 ## LUKS key setup
 


### PR DESCRIPTION
Make sure to point out the appropriate device for EFI systems when trying to locate the UUID for the encrypted device.

Just adding a sentence in the UUID section for clarity for EFI systems.  I can see the argument about it's importance but since I just recently performed this on an EFI system, I saw the value of adding this in here for clarity for those who are still new to this unique process.