### PR TITLE
ci: split scripts, add commit lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,17 +1,42 @@
 name: Check PR
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  only:
+  contents:
     name: Check formatting and links
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/void-linux/void-linux:latest-mini-x86_64-musl
+      image: ghcr.io/void-linux/void-linux:latest-full-x86_64-musl
     steps:
       - name: Prepare container
         run: |
           xbps-install -Syu || xbps-install -Syu xbps
           xbps-install -yu
-          xbps-install -y mdbook-linkcheck vmdfmt git findutils
-      - uses: actions/checkout@v1
-      - run: ./res/ci/format.sh
+          xbps-install -y mdbook-linkcheck vmdfmt git findutils bash
+      - name: Checkout
+        id: checkout
+        uses: classabbyamp/treeless-checkout-action@v1
+      - name: Check summary
+        if: steps.checkout.conclusion == 'success'
+        run: res/ci/check-summary.sh
+      - name: Check formatting
+        if: success() || failure()
+        run: res/ci/format.sh
+      - name: Check links
+        if: success() || failure()
+        run: res/ci/linkcheck.sh
+  commits:
+    name: Check commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: classabbyamp/treeless-checkout-action@v1
+      - name: Check commit messages
+        run: res/ci/commit-lint.sh

--- a/res/ci/check-summary.sh
+++ b/res/ci/check-summary.sh
@@ -2,6 +2,8 @@
 
 ERROR=0
 
+printf "\n\033[37;1m=> Checking SUMMARY.md\033[m\n"
+
 cd src/ || exit 2
 
 # summary is the list of files taken from SUMMARY.md - unused for now
@@ -11,8 +13,8 @@ files="$( find . -type f -name '*.md' -not -name "SUMMARY.md" )"
 
 for file in $files
 do
-    if ! grep "$file" ./SUMMARY.md >/dev/null ; then
-        printf "\033[31;1m=> $file not in SUMMARY\033[m\n"
+    if ! grep -q "$file" ./SUMMARY.md ; then
+        printf "::error title=Summary Lint,file=src/SUMMARY.md::$file not in SUMMARY.md\n"
         ERROR=1
     fi
 done

--- a/res/ci/commit-lint.sh
+++ b/res/ci/commit-lint.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+die() {
+	printf '%s\n' "$*" >&2
+	exit 1
+}
+
+command -v git >/dev/null 2>&1 ||
+die "neither chroot-git nor git could be found!"
+
+tip="$(git rev-list -1 --parents HEAD)"
+case "$tip" in
+	# This is a merge commit, pick last parent
+	*" "*" "*) tip="${tip##* }" ;;
+	# This is a non-merge commit, pick itself
+	*)         tip="${tip%% *}" ;;
+esac
+
+base="$(git merge-base origin/HEAD "$tip")"
+
+[ $(git rev-list --count "$tip" "^$base") -lt 20 ] || {
+	echo "::error title=Branch out of date::Your branch is too out of date. Please rebase on upstream and force-push."
+	exit 1
+}
+
+status=0
+
+for cmt in $(git rev-list --abbrev-commit $base..$tip)
+do
+    git cat-file commit "$cmt" |
+    awk -vC="$cmt" '
+    # skip header
+    /^$/ && !msg { msg = 1; next }
+    !msg { next }
+    # 3: long-line-is-banned-except-footnote-like-this-for-url
+    (NF > 2) && (length > 80) { print "::error title=Commit Lint::" C ": long line: " $0; exit 1 }
+    !subject {
+        if (length > 50) { print "::warning title=Commit Lint::" C ": subject is a bit long" }
+        if (!($0 ~ ":")) { print "::error title=Commit Lint::" C ": subject does not follow CONTRIBUTING.md guidelines"; exit 1 }
+        subject = 1; next
+    }
+    /^$/ { body = 1; next }
+    !body { print "::error title=Commit Lint::" C ": second line must be blank"; exit 1 }
+    ' || status=1
+done
+exit $status

--- a/res/ci/format.sh
+++ b/res/ci/format.sh
@@ -1,29 +1,15 @@
 #!/bin/sh
 
-git config --global --add safe.directory "$PWD"
-
-printf "\033[37;1m=> Checking links\033[m\n"
-RUST_LOG=linkcheck=debug mdbook-linkcheck -s
-LINKCHECK=$?
-
-# Format them
 printf "\n\033[37;1m=> Formatting tree\033[m\n"
 vmdfmt -l -w src/
 
 # Check Status
 if [ ! -z "$(git status --porcelain)" ] ; then
-    git diff
-    printf "\033[31;1m=> Working directory not clean, files to be formatted:\033[m\n"
-    git status
-    VMDFMT=1
-fi
-
-# Check SUMMARY.md
-printf "\n\033[37;1m=> Checking SUMMARY.md\033[m\n"
-res/ci/check-summary.sh
-SUMMARY=$?
-
-# Generate exit value
-if [ ! -z $VMDFMT ] || [ ! $LINKCHECK -eq 0 ] || [ ! $SUMMARY -eq 0 ] ; then
-    exit 2
+    git diff --color=always
+    printf "\033[31;1m=> Files which need to be formatted:\033[m\n"
+    for f in $(git status | grep -Po 'modified:\K.*$'); do
+        printf "$f\n"
+        printf "::error title=Formatting Lint,file=$f,line=1::File has improper formatting\n"
+    done
+    exit 1
 fi

--- a/res/ci/linkcheck.sh
+++ b/res/ci/linkcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# only show all the debug messages if ci is run with debug
+if [ "$RUNNER_DEBUG" ]; then
+    loglevel=debug
+else
+    loglevel=error
+fi
+
+printf "\033[37;1m=> Checking links\033[m\n"
+RUST_LOG="linkcheck=$loglevel" mdbook-linkcheck -s -c always


### PR DESCRIPTION
- res/ci: split CI steps into separate scripts
- res/ci/commit-lint.sh: add commit lint script
- .github/workflows/ci.yaml: split into multiple steps