### PR TITLE
texi2pdf and texi2html usage on Void with tlmgr

### DIFF
--- a/src/config/texlive.md
+++ b/src/config/texlive.md
@@ -99,9 +99,9 @@ For a full description, check:
 
 ## Texinfo PDF and HTML compilation with TeX Live
 Texinfo is the documentation system used by GNU and other projects and can
-output .info files (with `makeinfo`) to be used with the software `info` or can be
-converted into PDFs with `texi2pdf` and HTMLs with `texi2html`. Both
-**PDF and HTML conversions require a _texinfo.tex_ file which can be installed from tlmgr**.
+output .info files (with `makeinfo`) to be used with the software `info` or can
+be exported into PDFs with `texi2pdf` and HTMLs with `texi2html`. Both PDF and
+HTML conversions require a texinfo.tex file which can be installed from tlmgr.
 
 ```
 # tlmgr install texinfo

--- a/src/config/texlive.md
+++ b/src/config/texlive.md
@@ -98,6 +98,7 @@ For a full description, check:
 <https://www.tug.org/texlive/doc/tlmgr.html>
 
 ## Texinfo PDF and HTML compilation with TeX Live
+
 Texinfo is the documentation system used by GNU and other projects and can
 output .info files (with `makeinfo`) to be used with the software `info` or can
 be exported into PDFs with `texi2pdf` and HTMLs with `texi2html`. Both PDF and

--- a/src/config/texlive.md
+++ b/src/config/texlive.md
@@ -96,3 +96,19 @@ To update installed packages:
 For a full description, check:
 
 <https://www.tug.org/texlive/doc/tlmgr.html>
+
+## Texinfo PDF and HTML compilation with TeX Live
+Texinfo is the documentation system used by GNU and other projects and can
+output .info files (with `makeinfo`) to be used with the software `info` or can be
+converted into PDFs with `texi2pdf` and HTMLs with `texi2html`. Both
+**PDF and HTML conversions require a _texinfo.tex_ file which can be installed from tlmgr**.
+
+```
+# tlmgr install texinfo
+```
+
+Other missing files the .texi sources require can be installed the same way.
+
+More informations about texinfo on ctan, check:
+
+<https://ctan.org/pkg/texinfo>


### PR DESCRIPTION
A texinfo file can be exported in pdf and html using the two programs texi2pdf and texi2html. These programs require a file called texinfo.tex to compile first in latex and then in the actual format. This file is expected to be included with the texinfo installation or to be a dependency resolved by the package manager, Void uses tlmgr which doesn't automatically install the required package and probably this is why the error occur.

I added a short paragraph explaining the problem and making a fast solution to be used with tlmgr.