### PR TITLE
texlive.md: texinfo pdf compilation with texi2pdf

### DIFF
--- a/src/config/texlive.md
+++ b/src/config/texlive.md
@@ -96,3 +96,22 @@ To update installed packages:
 For a full description, check:
 
 <https://www.tug.org/texlive/doc/tlmgr.html>
+
+### Texinfo PDF compilation with texi2pdf
+
+Texinfo is the documentation system used by GNU and other projects. The source
+can be compiled into .info files (with `makeinfo`) and be used with the software
+`info` or they can be exported to PDF, HTML and other formats with `texi2pdf`
+and `texi2html`.
+
+Texinfo sources start including a .tex file with `\input texinfo` that implement
+the macros used throughout the document. The file texinfo.tex is required to
+export the document and it needs to be installed with tlmgr:
+
+```
+# tlmgr install texinfo
+```
+
+For more informations, check:
+
+<https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html#First-Line>


### PR DESCRIPTION
_I made a mess before with some pulls, this is the last one_

When texinfo is used to generate a pdf file it uses TeX with a macro file called `texinfo.tex`. As written on <https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html#First-Line>:

> These are in a file called texinfo.tex, which should have been installed on your system along with either the TeX or Texinfo software

Which doesn't happen here. The resolution is simple and only require to install texinfo with tlmgr.

I added a small paragraph explaining the problem, a short solution and a link with more details.