### PR TITLE
config/ssd.md: add missing steps for enabling LUKS

### DIFF
--- a/src/config/ssd.md
+++ b/src/config/ssd.md
@@ -96,9 +96,15 @@ If your root device is on LUKS, add `rd.luks.allow-discards` to
 GRUB_CMDLINE_LINUX_DEFAULT="rd.luks.allow-discards"
 ```
 
+Then update GRUB:
+
+```
+# update-grub
+```
+
 ### Verifying configuration
 
-To verify that you have configured TRIM correctly for LUKS, run:
+To verify that you have configured TRIM correctly for LUKS, reboot and run:
 
 ```
 # dmsetup table /dev/mapper/crypt_dev --showkeys


### PR DESCRIPTION
Hi.
I added some information that I found missing when trying to enable TRIM on a SSD with LUKS.
While this is not specific to Void, I believe it makes sense to have it alongside the other information about SSD (which is not Void-specific either), as it could be useful for people like me who are not familiar with such manipulations.
Let me know what you think.