### PR TITLE
Add a section to static.md for when the /current repository isn't found.

### DIFF
--- a/src/xbps/troubleshooting/static.md
+++ b/src/xbps/troubleshooting/static.md
@@ -33,3 +33,11 @@ that can no longer boot, it is recommended to chroot in using a Void
 installation medium and use the static tools from there, as it is unlikely that
 even a shell will work correctly on those systems. When using static XBPS with a
 glibc installation, the environment variable `XBPS_ARCH` needs to be set.
+
+## Repositories not found
+
+In some cases, repositories that were previously installed, and are necessary for reinstalling the xbps package, might no longer be installed. If this happens, you can try installing xbps with the following command.
+
+```
+xbps-install.static -R https://repo-default.voidlinux.org/current -Su xbps
+```


### PR DESCRIPTION
Yesterday, I accidently uninstalled the `xbps` package, and I went to the docs, followed the instructions, but when the `xbps` package was uninstalled, it also remove the /current repository, so I couldn't reinstall the `xbps` package.

This just gives instructions on how to install the `xbps` in the case that the /current repository is remove.