### PR TITLE
pipewire, pulse: small cleanups

### DIFF
--- a/src/config/media/pipewire.md
+++ b/src/config/media/pipewire.md
@@ -64,8 +64,7 @@ directly. This can be accomplished by running
 
 ```
 # mkdir -p /etc/pipewire/pipewire.conf.d
-# echo 'context.exec = [ { path = "/usr/bin/wireplumber" args = "" } ]' \
-    > /etc/pipewire/pipewire.conf.d/10-wireplumber.conf
+# ln -s /usr/share/examples/wireplumber/10-wireplumber.conf /etc/pipewire/pipewire.conf.d/
 ```
 
 for system configurations or, for per-user configurations, running
@@ -73,8 +72,7 @@ for system configurations or, for per-user configurations, running
 ```
 $ true "${XDG_CONFIG_HOME:=${HOME}/.config}"
 $ mkdir -p "${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d"
-$ echo 'context.exec = [ { path = "/usr/bin/wireplumber" args = "" } ]' \
-    > "${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d/10-wireplumber.conf"
+# ln -s /usr/share/examples/wireplumber/10-wireplumber.conf "${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d/"
 ```
 
 With either of these configurations, launching `pipewire` should be sufficient
@@ -119,8 +117,7 @@ autostart it from the same place where you start PipeWire. Alternatively, the
 
 ```
 # mkdir -p /etc/pipewire/pipewire.conf.d
-# echo 'context.exec = [ { path = "/usr/bin/pipewire" args = "-c pipewire-pulse.conf" } ]' \
-    > /etc/pipewire/pipewire.conf.d/20-pipewire-pulse.conf
+# ln -s /usr/share/examples/pipewire/20-pipewire-pulse.conf /etc/pipewire/pipewire.conf.d/
 ```
 
 for system configurations, or
@@ -128,8 +125,7 @@ for system configurations, or
 ```
 $ true "${XDG_CONFIG_HOME:=${HOME}/.config}"
 $ mkdir -p "${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d"
-$ echo 'context.exec = [ { path = "/usr/bin/pipewire" args = "-c pipewire-pulse.conf" } ]' \
-    > ${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d/20-pipewire-pulse.conf
+# ln -s /usr/share/examples/pipewire/20-pipewire-pulse.conf "${XDG_CONFIG_HOME}/pipewire/pipewire.conf.d/"
 ```
 
 for per-user configurations.

--- a/src/config/media/pulseaudio.md
+++ b/src/config/media/pulseaudio.md
@@ -7,13 +7,10 @@ with a D-BUS session bus (e.g. via `dbus-run-session`) or a D-BUS system bus
 For applications which use ALSA directly and don't support PulseAudio, the
 `alsa-plugins-pulseaudio` package can make them use PulseAudio through ALSA.
 
-The PulseAudio package comes with a service file, which is not necessary in most
-setups - the PulseAudio maintainers
-[discourage](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/)
-using a system-wide setup. Instead, PulseAudio will automatically start when
-needed. If it is not starting automatically, it can be started manually by
-invoking [pulseaudio(1)](https://man.voidlinux.org/pulseaudio.1) from the
-terminal as follows:
+PulseAudio will automatically start when needed. If it is not starting
+automatically, it can be started manually by invoking
+[pulseaudio(1)](https://man.voidlinux.org/pulseaudio.1) from the terminal as
+follows:
 
 ```
 $ pulseaudio --daemonize=no --exit-idle-time=-1


### PR DESCRIPTION
- config/media/pulseaudio: remove mention of pulse system service
    - if it's not recommended, why mention it? requires void-linux/void-packages#44141
- config/media/pipewire: symlink example config snippets
    - instead of writing them manually (requires void-linux/void-packages#44144)
