### PR TITLE
config/media/pipewire: rewrite for clarity

### DIFF
--- a/src/config/graphical-session/xorg.md
+++ b/src/config/graphical-session/xorg.md
@@ -105,13 +105,13 @@ be used to start X sessions from the console. For example, to start
 
 To start arbitrary programs together with an X session, add them in `~/.xinitrc`
 before the last line. For example, to start
-[pipewire(1)](https://man.voidlinux.org/pipewire.1) before starting i3, add
-`pipewire &` before the last line.
+[xscreensaver(1)](https://man.voidlinux.org/xscreensaver.1) before starting i3,
+add `xscreensaver &` before the last line.
 
-A `~/.xinitrc` file which starts `pipewire` and `i3` is shown below:
+A `~/.xinitrc` file which starts `xscreensaver` and `i3` is shown below:
 
 ```
-pipewire &
+xscreensaver &
 exec /bin/i3
 ```
 

--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -10,13 +10,16 @@ D-Bus is an IPC (inter-process communication) mechanism used by userspace
 software in Linux. D-Bus can provide a system bus and/or a session bus, the
 latter being specific to a user session.
 
-- To provide a system bus, you should [enable](./services/index.md) the `dbus`
-   service. This might require a system reboot to work properly.
+- To provide a system bus, you should
+   [enable](./services/index.md#enabling-services) the `dbus` service. This
+   might require a system reboot to work properly.
 - To provide a session bus, you can start a given program (usually a window
    manager or interactive shell) with
    [dbus-run-session(1)](https://man.voidlinux.org/dbus-run-session.1). Most
    desktop environments, if launched through an adequate display manager, will
-   launch a D-Bus session themselves.
+   launch a D-Bus session themselves. If a D-Bus session is active for the
+   current session, the environment variable `DBUS_SESSION_BUS_ADDRESS` should
+   be defined.
 
 Note that some software assumes the presence of a system bus, while other
 software assumes the presence of a session bus.


### PR DESCRIPTION
it seems a lot of people have trouble with this guide, and there's a lot of forks/options at each step. This rewrites the guide to streamline it into "basic setup" (wireplumber and optionally pw-pulse) and "optional setup" (everything else).

Also, this only documents the conf.d method as it's the most straightforward (IMO) and provides consistent results (wrt launch order and ensuring things are launched). I don't think we need to document every single option and overwhelm users, this guide is already very verbose.

closes #672

~~Still TODO:~~

- [x] improve Troubleshooting section with common errors and spurious errors
- [x] is the video group needed for video streams (like webcams) without elogind?
- [x] should the guide also have something about wayland screensharing with pipewire?
