### PR TITLE
config/media/index: doesn't need audio group with seatd

### DIFF
--- a/src/config/media/index.md
+++ b/src/config/media/index.md
@@ -9,5 +9,5 @@ To setup audio on your Void Linux system you have to decide if you want to use
 Some applications require PulseAudio, especially closed source programs, but
 [PipeWire](./pipewire.md) provides a drop-in replacement for PulseAudio.
 
-If [elogind](../session-management.md) is not enabled, it is necessary to be in
+If no [seat manager](../session-management.md) is enabled, it is necessary to be in
 the `audio` group in order to have access to audio devices.


### PR DESCRIPTION
Any seat manager allows accessing of audio device without the `audio` group. Not only elogind.