### PR TITLE
user-services.md: add session dbus and ssh example

### DIFF
--- a/src/config/media/pipewire.md
+++ b/src/config/media/pipewire.md
@@ -13,7 +13,8 @@ bus](../session-management.md#d-bus). If your desktop environment, window
 manager, or Wayland compositor is configured to provide this, no further
 configuration should be required. If not, the desktop environment, window
 manager, or Wayland compositor may need to be launched with
-[`dbus-run-session(1)`](https://man.voidlinux.org/dbus-run-session.1).
+[`dbus-run-session(1)`](https://man.voidlinux.org/dbus-run-session.1) or a [dbus
+user-service](../services/user-services.md#d-bus-session) should be setup.
 
 PipeWire also requires the
 [`XDG_RUNTIME_DIR`](../session-management.html#xdg_runtime_dir) environment

--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -15,11 +15,13 @@ latter being specific to a user session.
    might require a system reboot to work properly.
 - To provide a session bus, you can start a given program (usually a window
    manager or interactive shell) with
-   [dbus-run-session(1)](https://man.voidlinux.org/dbus-run-session.1). Most
-   desktop environments, if launched through an adequate display manager, will
-   launch a D-Bus session themselves. If a D-Bus session is active for the
-   current session, the environment variable `DBUS_SESSION_BUS_ADDRESS` should
-   be defined.
+   [dbus-run-session(1)](https://man.voidlinux.org/dbus-run-session.1).
+   Alternatively, you can create a [dbus
+   user-service](./services/user-services.md#d-bus-session). Most desktop
+   environments, if launched through an adequate display manager, will launch a
+   D-Bus session themselves. If a D-Bus session is active for the current
+   session, the environment variable `DBUS_SESSION_BUS_ADDRESS` should be
+   defined.
 
 Note that some software assumes the presence of a system bus, while other
 software assumes the presence of a session bus.


### PR DESCRIPTION
Added examples for setting up a session dbus and ssh-agent via user-services. References to setting up a session dbus were made in pipewire.md and session-management.md .
