### PR TITLE
config/session-management: add pam_rundir to xdg_runtime_dir

### DIFF
--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -62,6 +62,15 @@ user-specific runtime files.
 Install [elogind](#elogind) as your session manager to automatically set up
 `XDG_RUNTIME_DIR`.
 
+Install the `pam_rundir` package and add the following line to
+`/etc/pam.d/system-login` in the sessions block:
+
+`session optional pam_rundir.so`
+
+This will automatically create and destroy `XDG_RUNTIME_DIR` as
+`/run/user/<UID>` upon user login and logout. Please note that this does not set
+the `XDG_RUNTIME_DIR` environment variable automatically.
+
 Alternatively, manually set the environment variable through the shell. Make
 sure to create a dedicated user directory and set its permissions to `700`. A
 good default location is `/run/user/$(id -u)`.


### PR DESCRIPTION
<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->

this pr adds a paragraph underneath XDG_RUNTIME_DIR that describes how to use pam_rundir to set it up, as this in my mind is more helpful than just telling users to install elogind or to set it up manually (just adding an alternative instruction) ive tried to keep it as close to the guidelines as possible, but i may have missed something >w< so any feedback would be appreciated meow !!! :3
