### PR TITLE
config/containers-and-vms/libvirt.md: Mention `qemu` for virt-manager/virt-install

### DIFF
--- a/src/config/containers-and-vms/libvirt.md
+++ b/src/config/containers-and-vms/libvirt.md
@@ -25,7 +25,8 @@ the `dbus` service, `libvirtd` will grant necessary privileges to any user added
 to the `libvirt` group.
 
 An alternative to `virsh` is provided by the `virt-manager` and
-`virt-manager-tools` packages.
+`virt-manager-tools` packages. The default QEMU/KVM system connection requires
+the `qemu` package.
 
 For general information on libvirt, refer to [the libvirt
 wiki](https://wiki.libvirt.org/page/Main_Page) and [the wiki's


### PR DESCRIPTION
Include the `qemu` package in [the libvirt section](https://docs.voidlinux.org/config/containers-and-vms/libvirt.html), preventing `virt-manager`'s "Error: No hypervisor options were found for this connection."

Could save people some troubleshooting over the simple fact that QEMU isn't installed
