### PR TITLE
Update chroot.md with network requirement hint for xchroot

### DIFF
--- a/src/installation/guides/chroot.md
+++ b/src/installation/guides/chroot.md
@@ -142,8 +142,9 @@ methods.
 ### Entering the Chroot
 
 [xchroot(1)](https://man.voidlinux.org/xchroot.1) (from `xtools`) can be used to
-set up and enter the chroot. Alternatively, this can be [done
-manually](../../config/containers-and-vms/chroot.md#manual-method).
+set up and enter the chroot. Make sure that a
+[network connection](../../config/network/index.md) is established. Alternatively,
+this can be [done manually](../../config/containers-and-vms/chroot.md#manual-method).
 
 ```
 # xchroot /mnt /bin/bash


### PR DESCRIPTION
When following the [Installation via chroot](https://docs.voidlinux.org/installation/guides/chroot.html#installation-via-chroot-x86x86_64aarch64) guide, I encountered the small issue that ``xchroot`` would return the message ``special device /etc/resolv.conf does not exist.`` I thought that maybe a hint indicating to ensure that a network connection is configured might clear this up.