### PR TITLE
src/theme/index.hbs: make the search button into a button

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -108,7 +108,7 @@
 					{{/if}}
 					{{#if search_enabled}}
 					<li>
-						<a id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">
+						<button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
 								<path d="M7.5 13c3.04 0 5.5-2.46 5.5-5.5S10.54 2 7.5 2 2 4.46 2 7.5 4.46 13 7.5 13zm4.55.46C10.79 14.43 9.21 15 7.5 15 3.36 15 0 11.64 0 7.5S3.36 0 7.5 0C11.64 0 15 3.36 15 7.5c0 1.71-.57 3.29-1.54 4.55l6.49 6.49-1.41 1.41-6.49-6.49z"/>
 							</svg>


### PR DESCRIPTION
Small change to help with accessibility, by allowing the search button
to be activated using the keyboard only.
