### PR TITLE
theme/css/general.css: emphasize active sidebar item

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -202,7 +202,14 @@ svg {
 	text-decoration: none;
 }
 #sidebar a.active {
-	color: var(--sidebar-active);
+	display: block;
+	padding: 0.5em;
+	width: 100%;
+	background-color: var(--sidebar-active);
+	color: var(--bg);
+}
+#sidebar a.active::after {
+	content: "" / " selected";
 }
 
 #sidebar-toggle {


### PR DESCRIPTION
May (help) close https://github.com/void-linux/void-docs/issues/803, appends a bullet character (U+2022, •) to the end of a selected item in the sidebar for visibility.

For screen readers, this should render as "selected" instead.

![Example](https://github.com/user-attachments/assets/e957f12c-6b17-4804-9fff-34574318f122)

(I would've tried to color the background differently but I'm not a CSS wizard and this seemed more practical.)