### PR TITLE
config/graphical-session: hint to font installation for compositors

### DIFF
--- a/src/config/graphical-session/fonts.md
+++ b/src/config/graphical-session/fonts.md
@@ -1,5 +1,16 @@
 # Fonts
 
+A number of fonts and font collections are [available from
+XBPS](../../xbps/index.md#finding-files-and-packages). `dejavu-fonts-ttf` or
+`xorg-fonts` are a good baseline if you're unsure of what to pick.
+`noto-fonts-ttf` contains fonts for many languages and scripts. `noto-fonts-cjk`
+extends this with fonts for Chinese, Japanese, and Korean, and
+`noto-fonts-emoji` provides emojis. `nerd-fonts` provides a number of fonts with
+special characters like custom icons included.
+
+Fonts not available from XBPS can be manually installed to either
+`/usr/share/fonts` (system-wide) or `~/.local/share/fonts` (per-user).
+
 To customize font display in your graphical session, you can use configurations
 provided in `/usr/share/fontconfig/conf.avail/`. To do so, create a symlink to
 the relevant `.conf` file in `/etc/fonts/conf.d/`, then use

--- a/src/config/graphical-session/wayland.md
+++ b/src/config/graphical-session/wayland.md
@@ -30,6 +30,9 @@ Void Linux currently packages the following Wayland compositors:
 - labwc: a window-stacking compositor, inspired by Openbox
 - Qtile: a dynamic tiling Wayland compositor (via qtile-wayland)
 
+Some compositors do not depend on any [fonts](./fonts.md), which can cause many
+applications to not work. Install a font package to fix this.
+
 ### Video drivers
 
 Both GNOME and KDE Plasma have EGLStreams backends for Wayland, which means they


### PR DESCRIPTION
https://github.com/void-linux/void-docs/issues/802

Links to `fonts.md` under `wayland.md` and adds a hint to `fonts.md` that fonts are usually packaged with the `font-` prefix.