### PR TITLE
installation/guides/chroot: fix ROOTFS method permissions

### DIFF
--- a/src/installation/guides/chroot.md
+++ b/src/installation/guides/chroot.md
@@ -130,7 +130,7 @@ matching your architecture.
 Unpack the tarball into the newly configured filesystems:
 
 ```
-# tar xvf void-<...>-ROOTFS.tar.xz -C /mnt
+# tar xpvf void-<...>-ROOTFS.tar.xz --xattrs-include='*.*' --numeric-owner -C /mnt
 ```
 
 ## Configuration


### PR DESCRIPTION
The `tar` command used in the "ROOTFS method" heading loses important permissions data.

For example, `unix_chkpwd` (a program that uses the [setUID bit](https://unix.stackexchange.com/a/422556) to allow some lockscreen programs to talk to PAM) may have missing sticky permissions, leading to user lockout.

### Using only tar xvf

```bash
# ls -l /mnt/usr/bin/unix_chkpwd
-rwxr-xr-x 1 root root 38880 Dec 26  2023 /mnt/usr/bin/unix_chkpwd
```

### Using Gentoo-style tar extraction

```bash
# ls -l /mnt/usr/bin/unix_chkpwd
-rwsr-xr-x 1 root root 38880 Dec 26  2023 /mnt/usr/bin/unix_chkpwd
```

This commit updates the documentation's `tar` command to emulate [what Gentoo does](https://wiki.gentoo.org/wiki/Handbook:AMD64/Installation/Stage#Installing_a_stage_file).