### PR TITLE
config/external-applications: document how java packages and alternatives work

### DIFF
--- a/src/config/external-applications.md
+++ b/src/config/external-applications.md
@@ -23,6 +23,39 @@ instead.
 | Ruby     | gem                            | `ruby-devel`    |
 | lua      | luarocks                       | `lua-devel`     |
 
+### Java
+
+Void provides LTS versions of the OpenJDK development kits and runtimes.
+Currently, versions 8, 11, 17, and 21 are available. To run Java-based
+applications, install the Java Runtime Environment of the desired version. To
+build Java-based programs, install the Java Development Kit of the desired
+version (and optionally other components listed below).
+
+| Void Package           | Description              |
+|------------------------|--------------------------|
+| `openjdkX`             | Java Development Kit     |
+| `openjdkX-jre`         | Java Runtime Environment |
+| `openjdkX-doc`         | Developer documentation  |
+| `openjdkX-src`         | Java source code         |
+| `openjdkX-jmods`       | Java modules             |
+| `openjdkX-static-libs` | Java static libraries    |
+
+To facilitate installing multiple Java versions in parallel, Void's OpenJDK
+packages use
+[`xbps-alternatives(1)`](https://man.voidlinux.org/man1/xbps-alternatives.1) to
+select the default JDK and JRE. Each `openjdkX` package provides the `jdk`
+alternative group, and each `openjdkX-jre` package provides the `java`
+alternative group.
+
+These alternative groups manage the symlinks at `/usr/lib/jvm/default-jdk` and
+`/usr/lib/jvm/default-jre`. These are used to set the `JAVA_HOME` environment
+variables and add Java utilities to your `PATH` via a profile script
+(`/etc/profile.d/jdk.sh`).
+
+When installing a Java package for the first time, you may need to re-login or
+run `source /etc/profile.d/jdk.sh` in your terminal session to update these
+variables.
+
 ## Restricted Packages
 
 Some packages have legal restrictions on their distribution (e.g. Discord), may

--- a/src/config/graphical-session/wayland.md
+++ b/src/config/graphical-session/wayland.md
@@ -51,18 +51,15 @@ which can be either elogind or seatd. Enabling them is explained in the
 
 ### Native applications
 
-[Qt5](https://wayland.freedesktop.org/qt5.html)-based applications require
-installing the `qt5-wayland` package and setting the environment variable
-`QT_QPA_PLATFORM=wayland-egl` to enable their Wayland backend. Some KDE specific
-applications also require installing the `kwayland` package.
-[EFL](https://wayland.freedesktop.org/efl.html)-based applications require
-setting the environment variable `ELM_DISPLAY=wl`, and can have issues without
-it, due to not supporting XWayland properly. [SDL](https://libsdl.org)-based
-applications require setting the environment variable `SDL_VIDEODRIVER=wayland`.
+Qt5-based applications require installing the `qt5-wayland` package and setting
+the environment variable `QT_QPA_PLATFORM=wayland-egl` to enable their Wayland
+backend. Some KDE specific applications also require installing the `kwayland`
+package. EFL-based applications require setting the environment variable
+`ELM_DISPLAY=wl`, and can have issues without it, due to not supporting XWayland
+properly. [SDL](https://libsdl.org)-based applications require setting the
+environment variable `SDL_VIDEODRIVER=wayland`.
 [GTK+](https://wiki.gnome.org/Initiatives/Wayland/GTK%2B)-based applications
-should use the Wayland backend automatically. Information about other toolkits
-can be found in the [Wayland
-documentation](https://wayland.freedesktop.org/toolkits.html).
+should use the Wayland backend automatically.
 
 Media applications, such as [mpv(1)](https://man.voidlinux.org/mpv.1),
 [vlc(1)](https://man.voidlinux.org/vlc.1) and `imv` work natively on Wayland.


### PR DESCRIPTION
seems to have been a fair amount of confusion about this.
