### PR TITLE
Fix typo: system -> service

### DIFF
--- a/src/config/services/index.md
+++ b/src/config/services/index.md
@@ -125,7 +125,7 @@ directory in `/var/service/`:
 # ln -s /etc/sv/<service> /var/service/
 ```
 
-If the system is not currently running, the service can be linked directly into
+If the service is not currently running, the service can be linked directly into
 the `default` [runsvdir](#runsvdirs):
 
 ```


### PR DESCRIPTION
This PR corrects what I think is a typo in the services documentation.

To enable a service we link it directly into the default runsvdir if _the service_ is not currently running. If the _system_ is not currently running, then enabling services becomes a bit harder.
