### PR TITLE
Update link to upstream iwd documentation page

### DIFF
--- a/src/config/network/iwd.md
+++ b/src/config/network/iwd.md
@@ -20,16 +20,14 @@ operate `iwctl`.
 
 ## Configuration
 
-Configuration options and examples are described below. Consult the relevant
-manual pages and the [upstream
-documentation](https://iwd.wiki.kernel.org/networkconfigurationsettings) for
-further information.
+Configuration options and examples are described below. Consult
+[iwd.network(5)](https://man.voidlinux.org/iwd.network.5) for further
+information.
 
 ### Daemon configuration
 
 The main configuration file is located in `/etc/iwd/main.conf`. If it does not
-exist, you may create it. It is documented in
-[iwd.config(5)](https://man.voidlinux.org/iwd.config.5).
+exist, you may create it.
 
 ### Network configuration
 


### PR DESCRIPTION
The old link redirects to the kernel's rather funny 404 page.

<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->
