### PR TITLE
config/network/wpa_supplicant: use the default wpa_supplicant conf

### DIFF
--- a/src/config/network/wpa_supplicant.md
+++ b/src/config/network/wpa_supplicant.md
@@ -24,7 +24,7 @@ To use WPA-PSK, generate a pre-shared key with
 output to the relevant `wpa_supplicant.conf` file:
 
 ```
-# wpa_passphrase <MYSSID> <passphrase> >> /etc/wpa_supplicant/wpa_supplicant-<device_name>.conf
+# wpa_passphrase <MYSSID> <passphrase> >> /etc/wpa_supplicant/wpa_supplicant.conf
 ```
 
 ## WPA-EAP


### PR DESCRIPTION
to reduce confusion and make it easier to type out, just append it to the default conf file
