### PR TITLE
installation/guides/arm-devices/platforms: updates to rpi docs

### DIFF
--- a/src/installation/guides/arm-devices/platforms.md
+++ b/src/installation/guides/arm-devices/platforms.md
@@ -18,11 +18,11 @@ documentation](https://www.raspberrypi.com/documentation/computers/configuration
 
 ### Supported Models
 
-| Model                                       | Architecture |
-|---------------------------------------------|--------------|
-| 1 A, 1 B, 1 A+, 1 B+, Zero, Zero W, Zero WH | armv6l       |
-| 2 B                                         | armv7l       |
-| 3 B, 3 A+, 3 B+, Zero 2W, 4 B, 400, CM4, 5  | aarch64      |
+| Model                                                 | Architecture |
+|-------------------------------------------------------|--------------|
+| 1 A, 1 B, 1 A+, 1 B+, Zero, Zero W, Zero WH           | armv6l       |
+| 2 B                                                   | armv7l       |
+| 3 B, 3 A+, 3 B+, Zero 2W, 4 B, 400, CM4, 500, 5, CM5  | aarch64      |
 
 > It is possible to run the armv7l images on an RPi 3, as the RPi 3's CPU
 > supports both the Armv8 and Armv7 instruction sets. The difference between
@@ -59,6 +59,8 @@ can be used with the [modesetting Xorg
 driver](../../../config/graphical-session/xorg.md#modesetting) or
 [Wayland](../../../config/graphical-session/wayland.md).
 
+You may also need to uncomment the `dtoverlay=vc4-kms-v3d` line in `/boot/config.txt`.
+
 ### Hardware
 
 More configuration information can be found in the Raspberry Pi Foundation's
@@ -69,7 +71,7 @@ The `raspi-config` utility isn't available for Void Linux, so editing the
 
 #### Audio
 
-To enable the soundchip, add `dtparam=audio=on` to `/boot/config.txt`.
+To enable audio, you may need to uncomment `dtparam=audio=on` in `/boot/config.txt`.
 
 #### Serial
 
@@ -101,12 +103,3 @@ configuration. It should show:
 $ i2cdetect -l
 i2c-1i2c          bcm2835 I2C adapter                 I2C adapter
 ```
-
-### Memory cgroup
-
-The kernel from the `rpi-kernel` package [disables the memory cgroup by
-default](https://github.com/raspberrypi/linux/commit/28aec65bb1743c9bfa53b036999f9835c889704e).
-
-This breaks workloads which use containers. Therefore, if you want to use
-containers on your Raspberry Pi, you need to enable memory cgroups by adding
-`cgroup_enable=memory` to `/boot/cmdline.txt`.


### PR DESCRIPTION
- should now support 500/CM5 (as of 6.6.67 at least)
- audio/video config.txt lines should now be uncommented by default
- memcg no longer required with new config
