### PR TITLE
Weston no longer has xwayland subpkg.

### DIFF
--- a/src/config/graphical-session/wayland.md
+++ b/src/config/graphical-session/wayland.md
@@ -80,7 +80,7 @@ Wayland natively.
 If an application doesn't support Wayland, it can still be used in a Wayland
 context. XWayland is an X server that bridges this gap for most Wayland
 compositors, and is installed as a dependency for most of them. Its package is
-`xorg-server-xwayland`. For Weston, the correct package is `weston-xwayland`.
+`xorg-server-xwayland`.
 
 ## Configuration
 


### PR DESCRIPTION
Weston no longer has xwayland subpkg; It has been rolled into the main package.

<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->
