### PR TITLE
fonts.md: change deprecated conf file to correct one

### DIFF
--- a/src/config/graphical-session/fonts.md
+++ b/src/config/graphical-session/fonts.md
@@ -20,7 +20,7 @@ reconfigure the `fontconfig` package.
 For example, to disable use of bitmap fonts:
 
 ```
-# ln -s /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf /etc/fonts/conf.d/
+# ln -s /usr/share/fontconfig/conf.avail/70-no-bitmaps-except-emoji.conf /etc/fonts/conf.d/
 # xbps-reconfigure -f fontconfig
 ```
 


### PR DESCRIPTION
Command for creating symlink used a deprecated file for disabling bitmap fonts.

Edit:
When you run:
```bash
fc-conflist | grep no-bitmap
```
you'll see:
```bash
[flisak@void] ~  $ fc-conflist | grep no-bitmap
+ /etc/fonts/conf.d/70-no-bitmaps-except-emoji.conf: Reject bitmap fonts except bitmap emoji fonts
- /usr/share/fontconfig/conf.avail/70-no-bitmaps-and-emoji.conf: Reject bitmap fonts, including bitmap emoji fonts
- /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf: Reject bitmap fonts except bitmap emoji fonts (deprecated; use 70-no-bitmaps-except-emoji.conf)
[flisak@void] ~  $
```