### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["The Void Linux Team"]
-multilingual = false
 src = "src"
 title = "Void Linux Handbook"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10