### PR TITLE
config/network/index.md: Misleading dhcpcd setup for specific interfaces

### DIFF
--- a/src/config/network/index.md
+++ b/src/config/network/index.md
@@ -54,6 +54,11 @@ $ ip link show
 # ln -s /etc/sv/dhcpcd-enp3s0 /var/service/
 ```
 
+**Note**: Simply copying the dhcpcd-eth0 service for multiple other interfaces
+may not work as expected. If "supervise" or related symlink files exist in the
+copied directory, they must be removed—these files can cause conflicts due to
+shared runtime resources.
+
 For more information on configuring `dhcpcd`, refer to
 [dhcpcd.conf(5)](https://man.voidlinux.org/dhcpcd.conf.5)
 


### PR DESCRIPTION
Hello,

Completing the documentation to avoid confusion on setting voidlinux dhcpcd when multiple interfaces are present.

Thanks!

PS: I have read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md)

