### PR TITLE
Add Niri to wayland.md

### DIFF
--- a/res/README.md
+++ b/res/README.md
@@ -1,2 +1,2 @@
-The original cover variants, as suggested by @argosatcore on GitHub,
-are available in the `handbook-cover-variants.svg` file.
+The original cover variants, as suggested by @argosatcore on GitHub, are
+available in the `handbook-cover-variants.svg` file.

--- a/src/config/graphical-session/wayland.md
+++ b/src/config/graphical-session/wayland.md
@@ -27,6 +27,7 @@ Void Linux currently packages the following Wayland compositors:
 - Hikari: a stacking compositor with some tiling features
 - Cage: a Wayland kiosk
 - River: a dynamic tiling Wayland compositor
+- Niri: a scrolling-tiling Wayland compositor
 - labwc: a window-stacking compositor, inspired by Openbox
 - Qtile: a dynamic tiling Wayland compositor (via qtile-wayland)
 


### PR DESCRIPTION
I just added a small note about [Niri](https://github.com/YaLTeR/niri) in the Wayland compositors section (`config/graphical-session/wayland.md`). I ran `vmdfmt -w -l .` in the repository's root, it modified one file `res/README.md`, so I commited that one as well.