### PR TITLE
config/network: Also change the link to supervise symlink

### DIFF
--- a/src/config/network/index.md
+++ b/src/config/network/index.md
@@ -50,6 +50,7 @@ $ ip link show
 2: enp3s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
         link/ether ff:ff:ff:ff:ff:ff brd ff:ff:ff:f
 # cp -R /etc/sv/dhcpcd-eth0 /etc/sv/dhcpcd-enp3s0
+# ln -nsf /run/runit/supervise.dhcpcd-enp3s0 /etc/sv/dhcpcd-enp3s0/supervise"
 # sed -i 's/eth0/enp3s0/' /etc/sv/dhcpcd-enp3s0/run
 # ln -s /etc/sv/dhcpcd-enp3s0 /var/service/
 ```


### PR DESCRIPTION
In the section talking about interface-specific dhcpcd, the run script is modified with sed to have the proper interface name, but there is also the supervise symlink, pointing into /run/runit.

The target is "supervise.dhcpcd-eth0", which kind of works as-is, until you also have an actual eth0 interface that is handled by a dhcpcd supervised by runit.

So to avoid having this misleading symlink, change it to a proper target: "supervise.dhcpcd-enp3s0" in the sample code.