### PR TITLE
installation/guides/zfs.md: Fix typo

### DIFF
--- a/src/installation/guides/zfs.md
+++ b/src/installation/guides/zfs.md
@@ -159,7 +159,7 @@ the EFI system partition:
 # mkdir -p /mnt/boot
 # mount /dev/sda2 /mnt/boot
 # mkdir -p /mnt/boot/efi
-# mount /dev/sda1 /mnnt/boot/efi
+# mount /dev/sda1 /mnt/boot/efi
 ```
 
 ### Installation


### PR DESCRIPTION
This is a minor typo, but it is in a shell snippet which are often copy-pasted into a terminal, so it should be fixed.