### PR TITLE
installation/live-images/guide: add WPA3/SAE info

### DIFF
--- a/src/installation/live-images/guide.md
+++ b/src/installation/live-images/guide.md
@@ -40,9 +40,10 @@ Select your primary network interface. If you do not choose to use DHCP, you
 will be prompted to provide an IP address, gateway, and DNS servers.
 
 If you choose a wireless network interface, you will be prompted to provide the
-SSID, encryption type (`wpa` or `wep`), and password. If `void-installer` fails
-to connect to your network, you may need to exit the installer and configure it
-manually using [wpa_supplicant](../../config/network/wpa_supplicant.md) and
+SSID, encryption type (`wpa`, `wep`, or `sae`), and password. If
+`void-installer` fails to connect to your network, you may need to exit the
+installer and configure it manually using
+[wpa_supplicant](../../config/network/wpa_supplicant.md) and
 [dhcpcd](../../config/network/index.md#dhcpcd) before continuing.
 
 ## Source


### PR DESCRIPTION
<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->

Relates to my other pull request that adds  WPA3/SAE support to the installer: https://github.com/void-linux/void-mklive/pull/429.
Mentions `sae` as an option along with `wep` and `wpa` in the installation guide.