### PR TITLE
config/network/wpa_supplicant: add WPA3/SAE info

### DIFF
--- a/src/config/network/wpa_supplicant.md
+++ b/src/config/network/wpa_supplicant.md
@@ -39,7 +39,7 @@ $ echo -n <passphrase> | iconv -t utf16le | openssl md4
 ## WEP
 
 For WEP configuration, add the following lines to your device's
-`wpa-supplicant.conf`:
+`wpa_supplicant.conf`:
 
 ```
 network={
@@ -48,6 +48,19 @@ network={
     wep_key0="YOUR AP WEP KEY"
     wep_tx_keyidx=0
     auth_alg=SHARED
+}
+```
+
+## WPA3-SAE
+
+SAE (used for WPA3) can be configured in `wpa_supplicant.conf` as follows:
+
+```
+network={
+    ssid="MYSSID"
+    key_mgmt=SAE
+    sae_password="YOUR AP PASSWORD"
+    ieee80211w=2
 }
 ```
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->

Adds WPA3/SAE configuration info to wpa_supplicant page. Also changes `wpa-supplicant.conf` -> `wpa_supplicant.conf` in WEP section.

Related to https://github.com/void-linux/void-mklive/pull/429 and https://github.com/void-linux/void-docs/pull/861