### PR TITLE
src/installation/guides/zfs: typo fix

### DIFF
--- a/src/installation/guides/zfs.md
+++ b/src/installation/guides/zfs.md
@@ -58,7 +58,7 @@ guide apply to ZFS installations as well, except that
    no benefit to creating separate ZFS pools on a single disk.
 
 As needed, format the EFI system partition using
-[mkfs.vfat(8)](https://man.voidlinux.org/mkfs.vfat.8) and the the boot partition
+[mkfs.vfat(8)](https://man.voidlinux.org/mkfs.vfat.8) and the boot partition
 using [mke2fs(8)](https://man.voidlinux.org/mke2fs.8) or
 [mkfs.xfs(8)](https://man.voidlinux.org/mkfs.xfs.8). Initialize any swap space
 using [mkswap(8)](https://man.voidlinux.org).


### PR DESCRIPTION
fixed a typo: "the the" to "the"

<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->
