### PR TITLE
src/installation/guides/arm-devices/index: typo fix

### DIFF
--- a/src/installation/guides/arm-devices/index.md
+++ b/src/installation/guides/arm-devices/index.md
@@ -113,7 +113,7 @@ It is also possible to perform a [chroot installation](../chroot.md) using the
 appropriate architecture and base packages. Make sure to [prepare your storage
 medium](#custom-partition-layout) properly for the device.
 
-If doing this from a computer with an incompatible archtecture (such as x86_64),
+If doing this from a computer with an incompatible architecture (such as x86_64),
 install `binfmt-support`, enable the `binfmt-support` service, and install the
 relevant QEMU user emulator (like `qemu-user-aarch64` for aarch64 or
 `qemu-user-arm` for 32-bit ARM) before installing. If `binfmt-support` was


### PR DESCRIPTION
fixed a typo: "archtecture" to "architecture"
