### PR TITLE
src/installation/guides/arm-devices/raspberry-pi: typo fix

### DIFF
--- a/src/installation/guides/arm-devices/raspberry-pi.md
+++ b/src/installation/guides/arm-devices/raspberry-pi.md
@@ -113,5 +113,5 @@ configuration. It should show:
 
 ```
 $ i2cdetect -l
-i2c-1i2c          bcm2835 I2C adapter                 I2C adapter
+i2c-1          i2c          bcm2835 I2C adapter          I2C adapter
 ```


### PR DESCRIPTION
fixed a typo: separated “i2c-1i2c” to “i2c-1” and “i2c”
