### PR TITLE
config/graphical-session/graphics-drivers/nvidia: rewrite nouveau

### DIFF
--- a/src/config/graphical-session/graphics-drivers/nvidia.md
+++ b/src/config/graphical-session/graphics-drivers/nvidia.md
@@ -7,23 +7,33 @@ some documentation provided by Nvidia. It tends to perform well on older
 hardware, and is required to use a large portion of the available Wayland
 compositors.
 
-At the time of writing, graphics cards starting with second generation Maxwell
-(GTX 9xx) are unable to perform at their full potential with `nouveau`. This is
-because the `linux-firmware` collection is missing signed firmware blobs needed
-to reclock these cards past their boot frequencies.
+### OpenGL
 
-To use `nouveau` with Wayland, you only need the `mesa-dri` package, which
-provides the accelerated OpenGL driver. On X11, you also need an appropriate
-Xorg driver. You can either install `xf86-video-nouveau` or use the universal
-`modesetting` driver bundled with Xorg (this is the only option on Tegra based
-ARM boards). The former can make use of GPU-specific 2D acceleration paths,
-which is primarily useful on older cards with specialized fixed function
-hardware (the `modesetting` driver will accelerate 2D using OpenGL via GLAMOR).
-When in doubt, it's a good idea to try `xf86-video-nouveau` first.
+The accelerated OpenGL driver is provided by `mesa-dri`. This is a dependency of
+the `xorg` metapackage, but must be manually installed when using `xorg-minimal`
+or a Wayland compositor.
 
-> Note: `xf86-video-nouveau` is usually installed by default if you use the
-> `xorg` metapackage. If you use `xorg-minimal`, you will need to install it
-> manually, either directly or through `xorg-video-drivers`.
+### Vulkan
+
+Cards starting with Kepler (GTX 6xx) are supported by the Vulkan nouveau driver.
+Install `vulkan-loader` and `mesa-vulkan-nouveau`. Older cards may perform
+poorly or unreliably with Vulkan.
+
+### Xorg
+
+The `xorg` metapackage pulls in the `xf86-video-nouveau` video driver. This will
+need to be manually installed when `xorg-minimal` is installed instead. You can
+also use the universal `modesetting` driver bundled with Xorg (this is the only
+option on Tegra-based ARM boards). When in doubt, it's a good idea to try
+`xf86-video-nouveau` first. This driver will likely perform better.
+
+### Reclocking
+
+Only first generation Maxwell, Kepler, and some Tesla cards support manual
+reclocking. Cards past Turing (GTX 16xx) support automatic reclocking. Graphics
+cards starting with second generation Maxwell (GTX 9xx) do not support
+reclocking because the `linux-firmware` collection is missing signed firmware
+blobs needed to reclock these cards past their boot frequencies.
 
 ## nvidia (Proprietary Driver)
 


### PR DESCRIPTION
Mesa's NVK driver is getting better and more popular. Time to add instructions in the handbook for it. Went ahead and divided the nouveau section into subsections like the other driver pages.

Note that the section divisions are unnecessary for the proprietary driver because it unifies all of the APIs into one package.