### PR TITLE
config/graphical-session/wayland: update web browsers

### DIFF
--- a/src/config/graphical-session/wayland.md
+++ b/src/config/graphical-session/wayland.md
@@ -68,14 +68,10 @@ Media applications, such as [mpv(1)](https://man.voidlinux.org/mpv.1),
 
 #### Web browsers
 
-Mozilla Firefox ships with a Wayland backend which is disabled by default. To
-enable the Wayland backend, either set the environment variable
-`MOZ_ENABLE_WAYLAND=1` before running `firefox` or use the provided
-`firefox-wayland` script.
-
-Browsers based on GTK+ or Qt5, such as Midori and
-[qutebrowser(1)](https://man.voidlinux.org/qutebrowser.1), should work on
-Wayland natively.
+Mozilla Firefox and Google Chromium support Wayland by default. Browsers based
+on GTK+ or Qt (e.g. [qutebrowser(1)](https://man.voidlinux.org/qutebrowser.1))
+should work on Wayland natively, given their toolkit is [configured
+properly](#native-applications).
 
 #### Running X applications inside Wayland
 


### PR DESCRIPTION
Simple update on the web browsers section of the Wayland manual. I thought I'd keep the snippet about the `firefox-wayland` script to avoid confusion.

[Firefox 121: Defaults to Wayland](https://www.firefox.com/en-US/firefox/121.0/releasenotes/#:~:text=On%20Linux%2C%20Firefox%20now%20defaults%20to%20the%20Wayland%20compositor%20when%20available%20instead%20of%20XWayland%2E)
[Chromium 140: Defaults to Wayland](https://issues.chromium.org/issues/40083534#comment599)