### PR TITLE
kde.md: add System Sound Themes and Browser Integration sections

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -76,5 +76,6 @@ exclude = [
 	'freedesktop\.org',
 	'libressl\.org',
 	'gnu\.org',
+	'kde\.org',
 ]
 user-agent = "Mozilla/5.0"

--- a/src/config/graphical-session/kde.md
+++ b/src/config/graphical-session/kde.md
@@ -34,3 +34,15 @@ package. If you want video thumbnails, the `ffmpegthumbs` package is also
 necessary. Enable previews in "Control" -> "Configure Dolphin" -> "General" ->
 "Previews" by checking the corresponding boxes. File previews will be shown for
 the selected file types after clicking "Preview" in Dolphin's toolbar.
+
+### System Sound Themes
+
+The `kde-plasma` package does not include the default KDE Plasma system sounds.
+If you wish to install the default system sounds theme, install the
+`ocean-sound-theme` package. Legacy sounds can be installed with the
+`oxygen-sounds` package.
+
+### Browser Integration
+
+If you wish to enable browser integration, install the
+`plasma-browser-integration` package.


### PR DESCRIPTION
Added sections documenting system sound themes and browser integration packages for KDE Plasma. Other distributions include these packages by default, so users may expect this functionality.

<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->
