### PR TITLE
book.toml: exclude kde.org

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -76,5 +76,6 @@ exclude = [
 	'freedesktop\.org',
 	'libressl\.org',
 	'gnu\.org',
+	'kde\.org',
 ]
 user-agent = "Mozilla/5.0"


### PR DESCRIPTION
The `userbase.kde.org` returns a 403 Forbidden even though the link is valid. I believe this is due to cloudflare bot detection on `kde.org`. Added  `kde.org` to the excluded list in `book.toml`.  

### Before
```
Checking links with mdbook-linkcheck ...
error: Server returned 403 Forbidden for https://userbase.kde.org/K3b
   ┌─ installation/live-images/prep.md:72:3
   │
72 │ - [K3B](https://userbase.kde.org/K3b)
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Server returned 403 Forbidden for https://userbase.kde.org/K3b
```

### After
```
Checking for mdbook-linkcheck ... /usr/bin/mdbook-linkcheck
Checking for vmdfmt ... /usr/bin/vmdfmt
Checking links with mdbook-linkcheck ...
Checks completed.

```
<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->
