### PR TITLE
Add a page on scanning, call out some packages in pipewire.md and amd.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -69,6 +69,7 @@
    - [TeX Live](./config/texlive.md)
    - [External Applications](./config/external-applications.md)
    - [Printing](./config/print/index.md)
+   - [Scanning](./config/scan/index.md)
    - [Containers and Virtual Machines](./config/containers-and-vms/index.md)
       - [Chroots and Containers](./config/containers-and-vms/chroot.md)
       - [libvirt](./config/containers-and-vms/libvirt.md)

--- a/src/config/graphical-session/graphics-drivers/amd.md
+++ b/src/config/graphical-session/graphics-drivers/amd.md
@@ -32,3 +32,8 @@ used, set the environment variable `LIBVA_DRIVER_NAME` to `radeonsi`.
 
 For VDPAU, install `libvdpau-va-gl`. Set the environment variable `VDPAU_DRIVER`
 to `va_gl`.
+
+## System Management Interface
+
+The `ROCm-SMI` package is required by some programs (like `btop`) in order to monitor
+the GPU.

--- a/src/config/scan/index.md
+++ b/src/config/scan/index.md
@@ -1,0 +1,61 @@
+# Scanning
+
+SANE (Scanner Access Now Easy) may be used to acquire images from scanners.
+
+As a prerequisite, install the `sane` package. To list discovered scanners:
+
+```
+$ scanimage -L
+```
+
+For additional options, consult
+[scanimage(1)](https://man.voidlinux.org/scanimage.1).
+
+## Scanner Drivers
+
+If the scanner is not discovered by `scanimage -L`, it may require a driver.
+
+### Driverless scanning
+
+Many different models of scanner support "driverless" scanning via the AirScan
+or WSD protocols. The `sane-airscan` driver may be utilized in these cases. This
+should cover the vast majority of modern scanner hardware.
+
+Applications acting as frontends to SANE will also use the `sane-airscan` driver
+if present, but do not depend on it, so it's recommended to install this and
+have it available.
+
+### Other scanner drivers
+
+If the scanner is not detected with `sane-airscan`, a manufacturer-specific
+driver may be required.
+
+#### HP
+
+See "[HP drivers](../print/index.md#hp-drivers)".
+
+#### Brother
+
+- `brother-brscan3`
+- `brother-brscan4`
+- `brother-brscan5`
+
+#### Epson
+
+- `imagescan`
+
+#### Samsung
+
+- `samsung-unified-driver`
+
+## Frontend Applications
+
+The traditional XSane frontend is available as `xsane`.
+
+### GNOME
+
+GNOME's Document Scanner is available as `simple-scan`.
+
+### KDE
+
+Two KDE applications are available: `skanpage` and `skanlite`.


### PR DESCRIPTION
This PR addresses a couple of stumbling blocks I've either experienced myself or come across while hanging out in #voidlinux

The changes are mostly calling out packages which aren't as discoverable as I figure they should be. No package depends upon them, so users might not know they are required for specific functionality.

I have also considered postinstall messages, e.g. the line about `ROCm-SMI` is _really_ about `btop` so maybe it doesn't belong on the docs page for AMD graphics drivers, and should be a postinst message for `btop` instead.

Or perhaps both: since `ROCm-SMI` _is_ undoubtedly related to AMD graphics drivers, the docs could mention it. And `btop` happens to have missing functionality if `ROCm-SMI` is not installed, so a postinst message could address this.

Let me know what you think.