### PR TITLE
connman: DHCP hostname update config

### DIFF
--- a/src/config/network/connman.md
+++ b/src/config/network/connman.md
@@ -48,3 +48,33 @@ Create `/etc/sv/connmand/conf` with the following content:
 ```
 OPTS="--nodnsproxy"
 ```
+
+## Prevent ConnMan from updating hostname
+
+[`connman.conf`](https://man.voidlinux.org/connman.conf) will by default allow
+ConnMan to update the system hostname, for example when a hostname is received
+from DHCP.
+
+ConnMan will update the value in `/proc/sys/kernel/hostname`. This can lead to a
+situation where ConnMan receives a stale hostname value from a DHCP server but
+`/etc/hostname`, `/etc/rc.conf`, etc contain the user configured hostname,
+conflicting with the value in `/proc/sys/kernel/hostname`. Applications and
+processes may obtain a hostname from different sources leading to
+inconsistencies.
+
+To disallow ConnMan from updating the system hostname, create
+`/etc/connman/main.conf` with the following configuration.
+
+```
+[General]
+AllowHostnameUpdates = false
+AllowDomainnameUpdates = false
+```
+
+If ConnMan set an undesired value in `/proc/sys/kernel/hostname`, ensure the
+configuration above is applied and the service restarted. And update to the
+preferred value.
+
+```
+# echo "<hostname>" > /proc/sys/kernel/hostname
+```


### PR DESCRIPTION
<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->

[ConnMan](https://docs.voidlinux.org/config/network/connman.html) default behavior is to update `/proc/sys/kernel/hostname` if it receives (a potentially stale) hostname from DHCP. If the user is not aware of this default behavior, it is [mentioned deep in the man page](https://man.voidlinux.org/connman.conf#EXAMPLE), it can be quite the rabbit hole to troubleshoot how there is a stale hostname being set. Ask me how I know :)

Given the potential impact on applications that take the hostname from `/proc/sys/kernel/hostname`, and not user configured values, this can lead to bit of mess on a newly installed system. I think that warrants highlighting this behavior and configuration to prevent this behavior in the docs.